### PR TITLE
Fixes a potential server crash when loading battlefront objects.

### DIFF
--- a/WorldServer/Services/World/BattlefrontService.cs
+++ b/WorldServer/Services/World/BattlefrontService.cs
@@ -332,8 +332,11 @@ namespace WorldServer.Services.World
                         // Entrances to warcamp necessary to compute objective rewards and spawn farm check
                         if (!_warcampEntrances.ContainsKey(res.ZoneId))
                             _warcampEntrances.Add(res.ZoneId, new Point3D[2]);
+                        if (res.Realm == 1 || res.Realm == 2)
+                            _warcampEntrances[res.ZoneId][res.Realm - 1] = new Point3D(res.X, res.Y, res.Z);
+                        else
+                            Log.Error("WorldMgr", $"Invalid realm value '{res.Realm}' for BattleFrontObject with Entry '{res.Entry}'. Realm must be 1 or 2.");
 
-                        _warcampEntrances[res.ZoneId][res.Realm - 1] = new Point3D(res.X, res.Y, res.Z);
                         break;
 
                     case (ushort)BattleFrontObjectType.WARCAMP_PORTAL:
@@ -354,7 +357,10 @@ namespace WorldServer.Services.World
                                 });
                         }
 
-                        _portalsToObjective[res.ZoneId][res.Realm - 1].Add(res.ObjectiveID, res);
+                        if (res.Realm == 1 || res.Realm == 2)
+                            _portalsToObjective[res.ZoneId][res.Realm - 1].Add(res.ObjectiveID, res);
+                        else
+                            Log.Error("WorldMgr", $"Invalid realm value '{res.Realm}' for BattleFrontObject with Entry '{res.Entry}'. Realm must be 1 or 2.");
                         break;
 
                     default:


### PR DESCRIPTION
The `LoadBattleFrontObjects` method in `BattlefrontService.cs` used the `Realm` property of a `BattleFrontObject` to calculate an array index. If the `Realm` value in the database was not 1 or 2, this would result in an `IndexOutOfRangeException`, crashing the server on startup.

This change adds validation to ensure the `Realm` is a valid value (1 or 2) before it is used as an array index. If the value is invalid, an error is logged, and the operation is skipped for that object, preventing the crash and providing a helpful error message for administrators.