### PR TITLE
Verify destination buffer size in Packet.Read

### DIFF
--- a/WorldServer/API/Packet.cs
+++ b/WorldServer/API/Packet.cs
@@ -64,7 +64,12 @@ namespace WorldServer.API
 
         public bool Read(byte[] destBuffer, int size)
         {
-            //TODO: Check buffer size
+            if (destBuffer == null)
+                throw new ArgumentNullException(nameof(destBuffer));
+
+            if (size > destBuffer.Length)
+                return false;
+
             if (size + _offset > _data.Length)
                 return false;
 
@@ -278,7 +283,8 @@ namespace WorldServer.API
             if (length > 0)
             {
                 byte[] data = new byte[length];
-                Read(data, (int)length);
+                if (!Read(data, (int)length))
+                    return null;
                 return data;
             }
             return null;
@@ -289,7 +295,8 @@ namespace WorldServer.API
             if (length > 0)
             {
                 byte[] data = new byte[length];
-                Read(data, (int)length);
+                if (!Read(data, length))
+                    return null;
                 return data;
             }
             return null;


### PR DESCRIPTION
## Summary
- Ensure Packet.Read checks destination buffer length before copying
- Handle failed reads in ReadByteArray methods

## Testing
- `dotnet build WorldServer/WorldServer.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository access denied)*

------
https://chatgpt.com/codex/tasks/task_e_68ab57644494833085513c99f168cd0e