### PR TITLE
Ensure encryption key length validation in CircularBuffer.Encrypt

### DIFF
--- a/WorldServer/API/CircularBuffer.cs
+++ b/WorldServer/API/CircularBuffer.cs
@@ -434,7 +434,12 @@ namespace WorldServer.API
 
         public void Encrypt(byte[] key, int offset, int size)
         {
-            //TODO:check buffer size
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+
+            if (key.Length < 256)
+                throw new ArgumentException("Key must be at least 256 bytes", nameof(key));
+
             System.Buffer.BlockCopy(key, 0, _tmpEncKey, 0, 256);
             int x, y, midpoint, pos;
             byte tmp = 0;


### PR DESCRIPTION
## Summary
- prevent potential runtime exceptions by validating key length before encryption

## Testing
- `dotnet build WorldServer/WorldServer.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5a1032608330918c0a2b0f0ac8d5