### PR TITLE
Remove name-based damage scaling

### DIFF
--- a/WorldServer/World/Abilities/CombatManager.cs
+++ b/WorldServer/World/Abilities/CombatManager.cs
@@ -1303,14 +1303,9 @@ namespace WorldServer.World.Abilities
                     damageInfo.Damage = (caster.ItmInterface.GetWeaponDamage(slot)) * damageInfo.CastTimeDamageMult;
                 }
 
-                //TODO : REMOVE BEFORE PRODUCTION
-                if (target is Player)
-                {
-                    if (target.Name.Contains("Ikthaleon"))
-                    {
-                        damageInfo.Damage *= 0.05f;
-                    }
-                }
+                // Optional debug scaling for targeted players.
+                if (target is Player plr && Math.Abs(plr.DebugDamageScaler - 1f) > 0.001f)
+                    damageInfo.Damage *= plr.DebugDamageScaler;
 
                 if (damageInfo.StatUsed > 0)
                 {

--- a/WorldServer/World/Objects/Player.cs
+++ b/WorldServer/World/Objects/Player.cs
@@ -3478,6 +3478,11 @@ namespace WorldServer.World.Objects
         public volatile float WarcampFarmScaler = 1.0f;
 
         /// <summary>
+        /// Configurable scalar for debugging or special-case damage tuning.
+        /// </summary>
+        public volatile float DebugDamageScaler = 1.0f;
+
+        /// <summary>
         /// Provides an opportunity for this unit to modify incoming ability damage from enemies.
         /// </summary>
         public override void ModifyHealIn(AbilityDamageInfo incHeal)


### PR DESCRIPTION
## Summary
- remove hardcoded per-name damage scaling in CombatManager
- introduce DebugDamageScaler property for configurable or flagged damage tuning

## Testing
- `dotnet build WorldServer/WorldServer.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5c9d7e188330975fb3bbdabdcb71