### PR TITLE
Fix TCP connection failure condition

### DIFF
--- a/FrameWork/NetWork/TCPManager.cs
+++ b/FrameWork/NetWork/TCPManager.cs
@@ -69,7 +69,7 @@ namespace FrameWork
                 return false;
 
             TCPManager Tcp = ConvertTcp<T>();
-            if (Tcp == null || Tcp.Start(IP, port))
+            if (Tcp == null || !Tcp.Start(IP, port))
             {
                 Log.Error(Name, "Can not connect to : " + IP + ":" + port);
                 return false;


### PR DESCRIPTION
## Summary
- Correct TCP client connection check to treat failed starts as errors

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `dotnet build ProjectWAR.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6e00570883308875c123b471c967