### PR TITLE
Ensure TCPManager read lock is released and add tests

### DIFF
--- a/FrameWork.Tests/FrameWork.Tests.csproj
+++ b/FrameWork.Tests/FrameWork.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../FrameWork/FrameWork.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/FrameWork.Tests/TCPManagerTests.cs
+++ b/FrameWork.Tests/TCPManagerTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using System.Threading;
+
+namespace FrameWork.Tests
+{
+    [TestClass]
+    public class TCPManagerTests
+    {
+        private static ReaderWriterLockSlim GetLock(TCPManager manager)
+        {
+            var field = typeof(TCPManager).GetField("ClientRWLock", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (ReaderWriterLockSlim)field.GetValue(manager);
+        }
+
+        [TestMethod]
+        public void GetClient_ValidIndex_ReleasesLock()
+        {
+            var manager = new TCPManager();
+            var rwLock = GetLock(manager);
+
+            var result = manager.GetClient(0);
+            Assert.IsNull(result);
+            Assert.IsFalse(rwLock.IsReadLockHeld);
+            Assert.AreEqual(0, rwLock.CurrentReadCount);
+        }
+
+        [TestMethod]
+        public void GetClient_InvalidIndex_ReleasesLock()
+        {
+            var manager = new TCPManager();
+            var rwLock = GetLock(manager);
+
+            var result = manager.GetClient(-1);
+            Assert.IsNull(result);
+            Assert.IsFalse(rwLock.IsReadLockHeld);
+            Assert.AreEqual(0, rwLock.CurrentReadCount);
+        }
+    }
+}

--- a/FrameWork/NetWork/TCPManager.cs
+++ b/FrameWork/NetWork/TCPManager.cs
@@ -167,12 +167,17 @@ namespace FrameWork
         {
             LockReadClients();
 
-            if (Id >= 0 && Id < Clients.Length)
-                return Clients[Id];
+            try
+            {
+                if (Id >= 0 && Id < Clients.Length)
+                    return Clients[Id];
 
-            UnLockReadClients();
-
-            return null;
+                return null;
+            }
+            finally
+            {
+                UnLockReadClients();
+            }
         }
 
         public void LockReadClients()


### PR DESCRIPTION
## Summary
- Ensure `TCPManager.GetClient` releases its read lock by using a `finally` block
- Add unit tests verifying locks are released for valid and invalid client IDs

## Testing
- ⚠️ `dotnet test FrameWork.Tests/FrameWork.Tests.csproj` (command not found)
- ⚠️ `apt-get update` (repository not signed; unable to install .NET SDK)


------
https://chatgpt.com/codex/tasks/task_e_68ab6ea7f6f48330ab713c4229e4c8bd