### PR TITLE
Ensure randomInt results are non-negative

### DIFF
--- a/Common/FastRandom.cs
+++ b/Common/FastRandom.cs
@@ -27,7 +27,7 @@ namespace Common
 
         public int randomInt(int range)
         {
-            return (int)randomLong() % range;
+            return fastAbs((int)randomLong() % range);
         }
 
         public int randomIntAbs()
@@ -131,7 +131,7 @@ namespace Common
 
         public int randomInt(int range)
         {
-            return (int)randomLong() % range;
+            return fastAbs((int)randomLong() % range);
         }
 
         public int randomIntAbs()

--- a/FrameWork.Tests/FastRandomTests.cs
+++ b/FrameWork.Tests/FastRandomTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Common;
+
+namespace FrameWork.Tests
+{
+    [TestClass]
+    public class FastRandomTests
+    {
+        [TestMethod]
+        public void RandomInt_ReturnsWithinRange()
+        {
+            var rand = new FastRandom(12345);
+            const int range = 100;
+            for (int i = 0; i < 1000; i++)
+            {
+                int value = rand.randomInt(range);
+                Assert.IsTrue(value >= 0 && value < range, $"Value {value} out of range");
+            }
+        }
+
+        [TestMethod]
+        public void SRandomInt_ReturnsWithinRange()
+        {
+            var rand = new SFastRandom(54321);
+            const int range = 100;
+            for (int i = 0; i < 1000; i++)
+            {
+                int value = rand.randomInt(range);
+                Assert.IsTrue(value >= 0 && value < range, $"Value {value} out of range");
+            }
+        }
+    }
+}

--- a/FrameWork.Tests/FrameWork.Tests.csproj
+++ b/FrameWork.Tests/FrameWork.Tests.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../FrameWork/FrameWork.csproj" />
+    <ProjectReference Include="../Common/Common.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />


### PR DESCRIPTION
## Summary
- apply `fastAbs` to the range modulus in `FastRandom` and `SFastRandom`
- add tests for `randomInt(int)` ensuring values fall within `[0, range)`
- reference `Common` project in test project

## Testing
- `dotnet test FrameWork.Tests/FrameWork.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab703f17e083309433dff6cbbf3bc7