### PR TITLE
Fix randomCharacterString length handling

### DIFF
--- a/Common/FastRandom.cs
+++ b/Common/FastRandom.cs
@@ -62,15 +62,20 @@ namespace Common
 
         public string randomCharacterString(int length)
         {
-            StringBuilder s = new StringBuilder();
+            StringBuilder s = new StringBuilder(length);
 
-            for (int i = 0; i < length / 2; i++)
+            for (int i = 0; i < length; i++)
             {
-                s.Append((char)('a' + fastAbs(randomDouble()) * 26d));
-                s.Append((char)('A' + fastAbs(randomDouble()) * 26d));
+                bool upper = randomBoolean();
+                int letterIndex = randomIntAbs(26);
+                char c = (char)((upper ? 'A' : 'a') + letterIndex);
+                s.Append(c);
             }
 
-            return s.ToString();
+            string result = s.ToString();
+            if (result.Length != length)
+                throw new InvalidOperationException("Generated string length does not match requested length");
+            return result;
         }
 
         public double standNormalDistrDouble()
@@ -166,15 +171,20 @@ namespace Common
 
         public string randomCharacterString(int length)
         {
-            StringBuilder s = new StringBuilder();
+            StringBuilder s = new StringBuilder(length);
 
-            for (int i = 0; i < length / 2; i++)
+            for (int i = 0; i < length; i++)
             {
-                s.Append((char)('a' + fastAbs(randomDouble()) * 26d));
-                s.Append((char)('A' + fastAbs(randomDouble()) * 26d));
+                bool upper = randomBoolean();
+                int letterIndex = randomIntAbs(26);
+                char c = (char)((upper ? 'A' : 'a') + letterIndex);
+                s.Append(c);
             }
 
-            return s.ToString();
+            string result = s.ToString();
+            if (result.Length != length)
+                throw new InvalidOperationException("Generated string length does not match requested length");
+            return result;
         }
 
         public double standNormalDistrDouble()

--- a/FrameWork.Tests/FastRandomTests.cs
+++ b/FrameWork.Tests/FastRandomTests.cs
@@ -29,5 +29,23 @@ namespace FrameWork.Tests
                 Assert.IsTrue(value >= 0 && value < range, $"Value {value} out of range");
             }
         }
+
+        [TestMethod]
+        public void RandomCharacterString_ReturnsCorrectLength()
+        {
+            var rand = new FastRandom(12345);
+            const int length = 25;
+            string result = rand.randomCharacterString(length);
+            Assert.AreEqual(length, result.Length);
+        }
+
+        [TestMethod]
+        public void SRandomCharacterString_ReturnsCorrectLength()
+        {
+            var rand = new SFastRandom(54321);
+            const int length = 40;
+            string result = rand.randomCharacterString(length);
+            Assert.AreEqual(length, result.Length);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- generate randomCharacterString with exact requested length and verify result
- add unit tests for randomCharacterString in FastRandom and SFastRandom

## Testing
- `dotnet test FrameWork.Tests/FrameWork.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab71adb7a883308f85efc6c7ef1e56