### PR TITLE
refactor: remove redundant buffer copy in ZOutputStream

### DIFF
--- a/FrameWork/zlib/ZOutputStream.cs
+++ b/FrameWork/zlib/ZOutputStream.cs
@@ -125,12 +125,10 @@ namespace FrameWork
 		{
 			if (len == 0)
 				return ;
-			int err;
-			byte[] b = new byte[b1.Length];
-			Array.Copy(b1, 0, b, 0, b1.Length); 
-			z.next_in = b;
-			z.next_in_index = off;
-			z.avail_in = len;
+                        int err;
+                        z.next_in = b1;
+                        z.next_in_index = off;
+                        z.avail_in = len;
 			do 
 			{
 				z.next_out = buf;


### PR DESCRIPTION
## Summary
- remove unnecessary array allocation in ZOutputStream.Write
- directly pass caller buffer to zlib stream

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7238a61c83308446bb5bc14ded61