### PR TITLE
Handle missing logging method and debug throttle code

### DIFF
--- a/LobbyServer/NetWork/Handler/AuthentificationHandlers.cs
+++ b/LobbyServer/NetWork/Handler/AuthentificationHandlers.cs
@@ -63,7 +63,7 @@ namespace LobbyServer.NetWork.Handler
                 }
                 else
                 {
-                    Log.Warn("AuthSession", $"Session token validation failed: {res}");
+                    Log.Notice("AuthSession", $"Session token validation failed: {res}");
                 }
             }
             catch (Exception e)

--- a/WorldServer/World/Objects/Player.cs
+++ b/WorldServer/World/Objects/Player.cs
@@ -1198,7 +1198,7 @@ namespace WorldServer.World.Objects
         {
 #if DEBUG
             return false;
-#endif
+#else
             if (IsBanned)
             {
                 if (_lastExileWarned + 30 < TCPManager.GetTimeStamp())
@@ -1252,6 +1252,7 @@ namespace WorldServer.World.Objects
             }
 
             return false;
+#endif
         }
 
         public bool BlocksChatFrom(Player sender)


### PR DESCRIPTION
## Summary
- replace non-existent `Log.Warn` call with `Log.Notice`
- guard `ShouldThrottle` logic with preprocessor directives to avoid unreachable code in debug builds

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `dotnet test` *(fails: The imported project "/Microsoft.Cpp.Default.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abaf87d5288330aa3ddbbfe80a874e