### PR TITLE
Guard unused chat throttle fields in debug builds

### DIFF
--- a/WorldServer/World/Objects/Player.cs
+++ b/WorldServer/World/Objects/Player.cs
@@ -1191,8 +1191,10 @@ namespace WorldServer.World.Objects
 
         private long _lastExileWarned;
 
+        #if !DEBUG
         private int _throttleCount;
         private long _lastMessageTime;
+        #endif
 
         public bool ShouldThrottle()
         {


### PR DESCRIPTION
## Summary
- prevent unused-field warnings in debug builds by defining chat throttling fields only for non-debug builds

## Testing
- `dotnet build WorldServer/WorldServer.csproj -c Debug` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb6bd659083309cbf36e0658bc377