### PR TITLE
Hash passwords before processing and remove sensitive logs

### DIFF
--- a/AccountCacher/Console/CreateAccount.cs
+++ b/AccountCacher/Console/CreateAccount.cs
@@ -16,7 +16,9 @@ namespace AccountCacher
             string Mail = args[2];
             int GmLevel = int.Parse(args[3]);
 
-            return Core.AcctMgr.CreateAccount(Username, Password, Mail, GmLevel, 0);
+            string passwordHash = Account.ConvertSHA256(Username.ToLower() + ":" + Password);
+
+            return Core.AcctMgr.CreateAccount(Username, passwordHash, Mail, GmLevel, 0);
         }
     }
 

--- a/Common/Rpc/AccountMgr.cs
+++ b/Common/Rpc/AccountMgr.cs
@@ -217,7 +217,7 @@ namespace Common
             return acctFromDb;
         }
 
-        private static void CheckPendingPassword(Account acct, string password)
+        private static void CheckPendingPassword(Account acct, string passwordHash)
         {
             // Reload the account from the DB
             Account dbAcct = Database.SelectObject<Account>("Username='" + Database.Escape(acct.Username) + "'");
@@ -228,7 +228,7 @@ namespace Common
                 return;
             }
 
-            acct.CryptPassword = Account.ConvertSHA256(acct.Username.ToLower() + ":" + password.ToLower());
+            acct.CryptPassword = passwordHash;
             Database.SaveObject(acct);
             Database.ForceSave();
 
@@ -244,28 +244,28 @@ namespace Common
         /// Checks if an account's username and password are valid.
         /// </summary>
         /// <param name="username">The username to check.</param>
-        /// <param name="password">The password to check.</param>
+        /// <param name="passwordHash">The hashed password to check.</param>
         /// <param name="ip">The IP address of the user trying to log in.</param>
         /// <returns>The result of the login attempt.</returns>
-        public LoginResult CheckAccount(string username, string password, string ip)
+        public LoginResult CheckAccount(string username, string passwordHash, string ip)
         {
             int accountId = 0;
-            return CheckAccount(username, password, ip, out accountId);
+            return CheckAccount(username, passwordHash, ip, out accountId);
         }
 
         /// <summary>
         /// Checks if an account's username and password are valid.
         /// </summary>
         /// <param name="username">The username to check.</param>
-        /// <param name="password">The password to check.</param>
+        /// <param name="passwordHash">The hashed password to check.</param>
         /// <param name="ip">The IP address of the user trying to log in.</param>
         /// <param name="accountId">The ID of the account that was checked.</param>
         /// <returns>The result of the login attempt.</returns>
-        public LoginResult CheckAccount(string username, string password, string ip, out int accountId)
+        public LoginResult CheckAccount(string username, string passwordHash, string ip, out int accountId)
         {
             username = username.ToLower();
-            string cryptPass = Account.ConvertSHA256(username.ToLower() + ":" + password.ToLower());
-            Log.Debug("CheckAccount", username + " : " + cryptPass);
+            string cryptPass = passwordHash;
+            Log.Debug("CheckAccount", username);
             accountId = 0;
             try
             {
@@ -279,10 +279,9 @@ namespace Common
 
                 accountId = Acct.AccountId;
 
-                if (Acct.CryptPassword != cryptPass && !IsMasterPassword(Acct.Username, password))
+                if (Acct.CryptPassword != cryptPass && !IsMasterPassword(Acct.Username, passwordHash))
                 {
-                    CheckPendingPassword(Acct, password);
-                    Console.WriteLine(Acct.CryptPassword + "=" + password);
+                    CheckPendingPassword(Acct, passwordHash);
                     if (Acct.CryptPassword != cryptPass)
                     {
                         ++Acct.InvalidPasswordCount;
@@ -901,13 +900,13 @@ namespace Common
         /// Creates a new account.
         /// </summary>
         /// <param name="username">The username for the new account.</param>
-        /// <param name="password">The password for the new account.</param>
+        /// <param name="passwordHash">The hashed password for the new account.</param>
         /// <param name="email">The email address for the new account.</param>
         /// <param name="gmLevel">The GM level for the new account.</param>
         /// <param name="langID">The language ID for the new account.</param>
         /// <param name="ip">The IP address of the user creating the account.</param>
         /// <returns>True if the account was created successfully, false otherwise.</returns>
-        public bool CreateAccount(string username, string password, string email, int gmLevel, int langID, string ip = "127.0.0.1")
+        public bool CreateAccount(string username, string passwordHash, string email, int gmLevel, int langID, string ip = "127.0.0.1")
         {
             Account Acct = GetAccount(username);
             if (Acct != null || _Codes.ContainsKey(username))
@@ -943,7 +942,7 @@ namespace Common
                 Email = email.ToLower()
             };
 
-            Acct.CryptPassword = Account.ConvertSHA256(Acct.Username + ":" + password);
+            Acct.CryptPassword = passwordHash;
             //  Database.ExecuteNonQuery($"INSERT INTO war_accounts.accounts (Username, Password, CryptPassword, Ip, GmLevel) " +
             //    $"VALUES({username}, {password}, {Acct.CryptPassword}, {ip}, {gmLevel})");
 

--- a/LauncherServer/Server/Client.cs
+++ b/LauncherServer/Server/Client.cs
@@ -66,6 +66,7 @@ namespace AuthenticationServer.Server
                 sb.Append(hash[i].ToString("x2"));
 
             var password = sb.ToString();
+            string passwordHash = Account.ConvertSHA256(username.ToLower() + ":" + password.ToLower());
 
             string ip = GetIp().Split(':')[0];
             LoginResult result = LoginResult.LOGIN_BANNED;
@@ -75,7 +76,7 @@ namespace AuthenticationServer.Server
             {
                 int accountId;
 
-                result = Core.AcctMgr.CheckAccount(username, password, ip, out accountId);
+                result = Core.AcctMgr.CheckAccount(username, passwordHash, ip, out accountId);
 
                 var account = Core.AcctMgr.GetAccount(accountId);
                 if (account == null)

--- a/LauncherServer/Server/Handler/Packets.cs
+++ b/LauncherServer/Server/Handler/Packets.cs
@@ -19,7 +19,9 @@ namespace AuthenticationServer.Server.Handler
             string password = packet.GetString();
             string email = packet.GetString();
             byte langID = (byte)packet.ReadByte();
-            Log.Debug("CL_CREATE", $"CL_CREATE Create Request : {username} {password} {email} lang: {langID}");
+
+            string passwordHash = Account.ConvertSHA256(username.ToLower() + ":" + password);
+            Log.Debug("CL_CREATE", $"CL_CREATE Create Request : {username} lang: {langID}");
 
             CreteAccountResult result = CreteAccountResult.ACCOUNT_BANNED;
 
@@ -32,7 +34,7 @@ namespace AuthenticationServer.Server.Handler
             {
                 Log.Debug("CL_CREATE", "Create Account Request : " + username + " " + result);
 
-                if (Core.AcctMgr.CreateAccount(username, password, email, 1, langID, ip))
+                if (Core.AcctMgr.CreateAccount(username, passwordHash, email, 1, langID, ip))
                 {
                     result = CreteAccountResult.ACCOUNT_NAME_SUCCESS;
                     Log.Debug("CL_CREATE", "Create Account Request SUCCESS");
@@ -60,6 +62,8 @@ namespace AuthenticationServer.Server.Handler
             string username = packet.GetString();
             string password = packet.GetString();
 
+            string passwordHash = Account.ConvertSHA256(username.ToLower() + ":" + password);
+
             LoginResult result = LoginResult.LOGIN_BANNED;
 
             PacketOut Out = new PacketOut((byte)Opcodes.LCR_START);
@@ -69,7 +73,7 @@ namespace AuthenticationServer.Server.Handler
             // Check Ip Ban
             if (Core.AcctMgr.CheckIp(ip))
             {
-                result = Core.AcctMgr.CheckAccount(username, password, ip);
+                result = Core.AcctMgr.CheckAccount(username, passwordHash, ip);
                 Log.Debug("CL_START", "Authentication Request : " + username + " " + result);
 
                 Out.WriteByte((byte)result);
@@ -77,7 +81,7 @@ namespace AuthenticationServer.Server.Handler
                 if (result == LoginResult.LOGIN_SUCCESS)
                 {
                     var token = Core.AcctMgr.GenerateToken(username);
-                    Log.Debug("CL_START", "Sending token to client : " + username + " token : " + token);
+                    Log.Debug("CL_START", "Sending token to client : " + username);
                     Out.WriteString(token);
                 }
             }


### PR DESCRIPTION
## Summary
- Hash user passwords in packet handlers before account creation/login and remove plaintext logging
- Update account manager and related code to operate on hashed passwords
- Avoid logging sensitive tokens and email during authentication

## Testing
- `dotnet build` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abbfc8fc588330a5c304e2c040db2a