### PR TITLE
Add lifecycle hooks to ServiceBase and ZoneService

### DIFF
--- a/WorldServer/Services/ServiceBase.cs
+++ b/WorldServer/Services/ServiceBase.cs
@@ -4,16 +4,36 @@ using WorldServer.Managers;
 namespace WorldServer.Services
 {
     /// <summary>
-    /// TODO work to do here
+    ///     Base class for all world server services providing common utilities
+    ///     such as database access and lifecycle hooks for startup and shutdown.
     /// </summary>
     public abstract class ServiceBase
     {
+        /// <summary>
+        ///     Convenience access to the world database.
+        /// </summary>
         protected static IObjectDatabase Database
         {
             get
             {
                 return WorldMgr.Database;
             }
+        }
+
+        /// <summary>
+        ///     Called when the service is starting.
+        /// </summary>
+        public virtual void Start()
+        {
+            Log.Info(GetType().Name, "Service starting");
+        }
+
+        /// <summary>
+        ///     Called when the service is stopping.
+        /// </summary>
+        public virtual void Stop()
+        {
+            Log.Info(GetType().Name, "Service stopping");
         }
     }
 }

--- a/WorldServer/Services/World/ZoneService.cs
+++ b/WorldServer/Services/World/ZoneService.cs
@@ -19,6 +19,18 @@ namespace WorldServer.Services.World
         public static List<Zone_Info> _Zone_Info;
         public static IOcclusionProvider OcclusionProvider = new Occlusion();
 
+        public override void Start()
+        {
+            base.Start();
+            WorldMgr.WorldUpdateStart();
+            WorldMgr.GroupUpdateStart();
+        }
+
+        public override void Stop()
+        {
+            base.Stop();
+        }
+
         [LoadingFunction(true)]
         public static void LoadZone_Info()
         {
@@ -40,8 +52,6 @@ namespace WorldServer.Services.World
                 }
             }
             LoadZoneJumps();
-            WorldMgr.WorldUpdateStart();
-            WorldMgr.GroupUpdateStart();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- document ServiceBase and add virtual Start/Stop methods with logging
- override Start/Stop in ZoneService and trigger world updates

## Testing
- `xbuild WorldServer/WorldServer.csproj` *(fails: CS1617 Invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68abc1cfcb24833083fed53f7c987e64