### PR TITLE
Validate launcher credentials and add tests

### DIFF
--- a/Common/Rpc/AccountMgr.cs
+++ b/Common/Rpc/AccountMgr.cs
@@ -18,7 +18,8 @@ namespace Common
     {
         ACCOUNT_NAME_BUSY = 0x00,
         ACCOUNT_NAME_SUCCESS = 0x01,
-        ACCOUNT_BANNED = 0x02
+        ACCOUNT_BANNED = 0x02,
+        ACCOUNT_INVALID = 0x03
     }
 
     public enum LoginResult
@@ -28,6 +29,7 @@ namespace Common
         LOGIN_BANNED = 0x02,
         LOGIN_NOT_ACTIVE = 0x03,
         LOGIN_PATCHER_NOT_ALLOWED = 0x04,
+        LOGIN_INVALID_INPUT = 0x05,
     };
 
     public enum AuthResult

--- a/LauncherServer.Tests/InputValidationTests.cs
+++ b/LauncherServer.Tests/InputValidationTests.cs
@@ -1,0 +1,59 @@
+using AuthenticationServer.Server.Handler;
+using Xunit;
+
+namespace LauncherServer.Tests
+{
+    public class InputValidationTests
+    {
+        [Theory]
+        [InlineData("validUser")]
+        [InlineData("User123_")]
+        public void ValidUsernames_Pass(string username)
+        {
+            Assert.True(InputValidator.IsValidUsername(username));
+        }
+
+        [Theory]
+        [InlineData("tooooooooooooooooooolongusername")]
+        [InlineData("bad!user")]
+        [InlineData("")]
+        public void InvalidUsernames_Fail(string username)
+        {
+            Assert.False(InputValidator.IsValidUsername(username));
+        }
+
+        [Theory]
+        [InlineData("StrongPass1!")]
+        [InlineData("Another$Pass123")]
+        public void ValidPasswords_Pass(string password)
+        {
+            Assert.True(InputValidator.IsValidPassword(password));
+        }
+
+        [Theory]
+        [InlineData("short")]
+        [InlineData("contains space")]
+        [InlineData("bad\npass")]
+        public void InvalidPasswords_Fail(string password)
+        {
+            Assert.False(InputValidator.IsValidPassword(password));
+        }
+
+        [Theory]
+        [InlineData("test@example.com")]
+        [InlineData("user.name+tag@domain.co")]
+        public void ValidEmails_Pass(string email)
+        {
+            Assert.True(InputValidator.IsValidEmail(email));
+        }
+
+        [Theory]
+        [InlineData("invalid-email")]
+        [InlineData("user@")]
+        [InlineData("")]
+        public void InvalidEmails_Fail(string email)
+        {
+            Assert.False(InputValidator.IsValidEmail(email));
+        }
+    }
+}

--- a/LauncherServer.Tests/LauncherServer.Tests.csproj
+++ b/LauncherServer.Tests/LauncherServer.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../LauncherServer/Server/Handler/InputValidation.cs" Link="InputValidation.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/LauncherServer/Server/Handler/InputValidation.cs
+++ b/LauncherServer/Server/Handler/InputValidation.cs
@@ -1,0 +1,26 @@
+using System.Text.RegularExpressions;
+
+namespace AuthenticationServer.Server.Handler
+{
+    public static class InputValidator
+    {
+        private static readonly Regex UsernameRegex = new("^[A-Za-z0-9_]{3,20}$", RegexOptions.Compiled);
+        private static readonly Regex PasswordRegex = new("^[\x21-\x7E]{6,50}$", RegexOptions.Compiled);
+        private static readonly Regex EmailRegex = new(@"^(([^<>()[\]\\.,;:\s@""']+(\.[^<>()[\]\\.,;:\s@""']+)*)|("".+""))@((\[[0-9]{1,3}(\.[0-9]{1,3}){3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$", RegexOptions.Compiled);
+
+        public static bool IsValidUsername(string username)
+        {
+            return !string.IsNullOrWhiteSpace(username) && UsernameRegex.IsMatch(username);
+        }
+
+        public static bool IsValidPassword(string password)
+        {
+            return !string.IsNullOrWhiteSpace(password) && PasswordRegex.IsMatch(password);
+        }
+
+        public static bool IsValidEmail(string email)
+        {
+            return !string.IsNullOrWhiteSpace(email) && EmailRegex.IsMatch(email);
+        }
+    }
+}

--- a/LauncherServer/Server/Handler/Packets.cs
+++ b/LauncherServer/Server/Handler/Packets.cs
@@ -15,17 +15,26 @@ namespace AuthenticationServer.Server.Handler
         {
             Client cclient = (Client)client;
 
-            string username = packet.GetString();
+            string username = packet.GetString()?.Trim();
             string password = packet.GetString();
-            string email = packet.GetString();
+            string email = packet.GetString()?.Trim();
             byte langID = (byte)packet.ReadByte();
+
+            PacketOut Out = new PacketOut((byte)Opcodes.LCR_CREATE);
+
+            if (!InputValidator.IsValidUsername(username) ||
+                !InputValidator.IsValidPassword(password) ||
+                !InputValidator.IsValidEmail(email))
+            {
+                Out.WriteByte((byte)CreteAccountResult.ACCOUNT_INVALID);
+                cclient.SendPacketNoBlock(Out);
+                return;
+            }
 
             string passwordHash = Account.ConvertSHA256(username.ToLower() + ":" + password);
             Log.Debug("CL_CREATE", $"CL_CREATE Create Request : {username} lang: {langID}");
 
             CreteAccountResult result = CreteAccountResult.ACCOUNT_BANNED;
-
-            PacketOut Out = new PacketOut((byte)Opcodes.LCR_CREATE);
 
             string ip = client.GetIp().Split(':')[0];
 
@@ -59,14 +68,22 @@ namespace AuthenticationServer.Server.Handler
         {
             Client cclient = (Client)client;
 
-            string username = packet.GetString();
+            string username = packet.GetString()?.Trim();
             string password = packet.GetString();
+
+            PacketOut Out = new PacketOut((byte)Opcodes.LCR_START);
+
+            if (!InputValidator.IsValidUsername(username) ||
+                !InputValidator.IsValidPassword(password))
+            {
+                Out.WriteByte((byte)LoginResult.LOGIN_INVALID_INPUT);
+                cclient.SendPacketNoBlock(Out);
+                return;
+            }
 
             string passwordHash = Account.ConvertSHA256(username.ToLower() + ":" + password);
 
             LoginResult result = LoginResult.LOGIN_BANNED;
-
-            PacketOut Out = new PacketOut((byte)Opcodes.LCR_START);
 
             string ip = client.GetIp().Split(':')[0];
 


### PR DESCRIPTION
## Summary
- add input validation helpers for usernames, passwords, and emails
- validate CL_CREATE and CL_START packets and return explicit errors
- cover validation edge cases with xUnit tests

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68abc431d5a48330b71686357d77bdec