### PR TITLE
Rename AuthenticationServer namespaces to LauncherServer

### DIFF
--- a/Common/Email/EmailClient.cs
+++ b/Common/Email/EmailClient.cs
@@ -3,9 +3,9 @@ using System.Net.Mail;
 using System.Threading;
 using System.Net;
 using System;
-using AuthenticationServer;
+using LauncherServer;
 
-namespace AuthenticationServer.Email
+namespace LauncherServer.Email
 {
     public class EmailClient
     {

--- a/Common/Rpc/AccountMgr.cs
+++ b/Common/Rpc/AccountMgr.cs
@@ -9,7 +9,7 @@ using FrameWork;
 using Google.ProtocolBuffers;
 using Common.Database.Account;
 using System.Text.RegularExpressions;
-using AuthenticationServer.Email;
+using LauncherServer.Email;
 using System.Threading;
 
 namespace Common

--- a/LauncherServer.Tests/InputValidationTests.cs
+++ b/LauncherServer.Tests/InputValidationTests.cs
@@ -1,4 +1,4 @@
-using AuthenticationServer.Server.Handler;
+using LauncherServer.Server.Handler;
 using Xunit;
 
 namespace LauncherServer.Tests

--- a/LauncherServer/Addon/WARAddon.cs
+++ b/LauncherServer/Addon/WARAddon.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Xml.Serialization;
 
-namespace AuthenticationServer.Addon
+namespace LauncherServer.Addon
 {
     [XmlRoot(ElementName = "VersionSettings")]
     public class aVersionSettings

--- a/LauncherServer/Config/LauncherConfig.cs
+++ b/LauncherServer/Config/LauncherConfig.cs
@@ -1,7 +1,7 @@
-﻿using AuthenticationServer.Server;
+﻿using LauncherServer.Server;
 using FrameWork;
 
-namespace AuthenticationServer.Config
+namespace LauncherServer.Config
 {
     [aConfigAttributes("Configs/Launcher.xml")]
     public class LauncherConfig : aConfig

--- a/LauncherServer/Console/State.cs
+++ b/LauncherServer/Console/State.cs
@@ -1,9 +1,9 @@
-﻿using AuthenticationServer.Server;
+﻿using LauncherServer.Server;
 using FrameWork;
 using System;
 using System.Collections.Generic;
 
-namespace AuthenticationServer.Console
+namespace LauncherServer.Console
 {
     [ConsoleHandler("state", 1, "Server State")]
     public class State : IConsoleHandler

--- a/LauncherServer/Core.cs
+++ b/LauncherServer/Core.cs
@@ -1,5 +1,5 @@
-﻿using AuthenticationServer.Config;
-using AuthenticationServer.Server;
+﻿using LauncherServer.Config;
+using LauncherServer.Server;
 using Common;
 using FrameWork;
 using FrameWork.Misc;
@@ -7,7 +7,7 @@ using System;
 using System.IO;
 using System.Reflection;
 
-namespace AuthenticationServer
+namespace LauncherServer
 {
     internal class Core
     {

--- a/LauncherServer/PatchMgr.cs
+++ b/LauncherServer/PatchMgr.cs
@@ -1,12 +1,12 @@
-﻿using AuthenticationServer.Server;
+﻿using LauncherServer.Server;
 using Common.Database.Account;
 using FrameWork;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Opcodes = AuthenticationServer.Server.Opcodes;
+using Opcodes = LauncherServer.Server.Opcodes;
 
-namespace AuthenticationServer
+namespace LauncherServer
 {
     public class PatchFile
     {

--- a/LauncherServer/Server/Client.cs
+++ b/LauncherServer/Server/Client.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 
-namespace AuthenticationServer.Server
+namespace LauncherServer.Server
 {
     public class Client : BaseClient
     {

--- a/LauncherServer/Server/Handler/InputValidation.cs
+++ b/LauncherServer/Server/Handler/InputValidation.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 
-namespace AuthenticationServer.Server.Handler
+namespace LauncherServer.Server.Handler
 {
     public static class InputValidator
     {

--- a/LauncherServer/Server/Handler/Packets.cs
+++ b/LauncherServer/Server/Handler/Packets.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text.RegularExpressions;
 
-namespace AuthenticationServer.Server.Handler
+namespace LauncherServer.Server.Handler
 {
     public class LauncherPackets : IPacketHandler
     {

--- a/LauncherServer/Server/Opcodes.cs
+++ b/LauncherServer/Server/Opcodes.cs
@@ -1,4 +1,4 @@
-﻿namespace AuthenticationServer.Server
+﻿namespace LauncherServer.Server
 {
     public enum Opcodes : byte
     {

--- a/LauncherServer/Server/PatcherFile.cs
+++ b/LauncherServer/Server/PatcherFile.cs
@@ -3,7 +3,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 
-namespace AuthenticationServer.Server
+namespace LauncherServer.Server
 {
     public class PatcherFile : IDisposable
     {

--- a/LauncherServer/Server/TCPServer.cs
+++ b/LauncherServer/Server/TCPServer.cs
@@ -1,7 +1,7 @@
 ﻿using FrameWork;
 using System.Collections.Generic;
 
-namespace AuthenticationServer.Server
+namespace LauncherServer.Server
 {
     public class TCPServer : TCPManager
     {


### PR DESCRIPTION
## Summary
- rename AuthenticationServer namespace usages to LauncherServer across server, config, console, patch manager, tests and common utilities
- update using directives for new LauncherServer namespaces

## Testing
- `dotnet build LauncherServer/LauncherServer.csproj -c Release` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68abc5a656a4833092400ec7f73f7e66