### PR TITLE
Add tests for launcher server handlers

### DIFF
--- a/Common/Rpc/AccountMgr.cs
+++ b/Common/Rpc/AccountMgr.cs
@@ -249,7 +249,7 @@ namespace Common
         /// <param name="passwordHash">The hashed password to check.</param>
         /// <param name="ip">The IP address of the user trying to log in.</param>
         /// <returns>The result of the login attempt.</returns>
-        public LoginResult CheckAccount(string username, string passwordHash, string ip)
+        public virtual LoginResult CheckAccount(string username, string passwordHash, string ip)
         {
             int accountId = 0;
             return CheckAccount(username, passwordHash, ip, out accountId);
@@ -263,7 +263,7 @@ namespace Common
         /// <param name="ip">The IP address of the user trying to log in.</param>
         /// <param name="accountId">The ID of the account that was checked.</param>
         /// <returns>The result of the login attempt.</returns>
-        public LoginResult CheckAccount(string username, string passwordHash, string ip, out int accountId)
+        public virtual LoginResult CheckAccount(string username, string passwordHash, string ip, out int accountId)
         {
             username = username.ToLower();
             string cryptPass = passwordHash;
@@ -350,7 +350,7 @@ namespace Common
         /// </summary>
         /// <param name="Ip">The IP address to check.</param>
         /// <returns>True if the IP address is not banned, false otherwise.</returns>
-        public bool CheckIp(string Ip)
+        public virtual bool CheckIp(string Ip)
         {
             Ip_ban ban = Database.SelectObject<Ip_ban>("Ip=LEFT('" + Database.Escape(Ip) + "', " + Database.SqlCommand_CharLength() + "(Ip))");
 
@@ -380,7 +380,7 @@ namespace Common
         /// </summary>
         /// <param name="username">The username of the account to generate the token for.</param>
         /// <returns>The new security token.</returns>
-        public string GenerateToken(string username)
+        public virtual string GenerateToken(string username)
         {
             username = username.ToLower();
 
@@ -908,7 +908,7 @@ namespace Common
         /// <param name="langID">The language ID for the new account.</param>
         /// <param name="ip">The IP address of the user creating the account.</param>
         /// <returns>True if the account was created successfully, false otherwise.</returns>
-        public bool CreateAccount(string username, string passwordHash, string email, int gmLevel, int langID, string ip = "127.0.0.1")
+        public virtual bool CreateAccount(string username, string passwordHash, string email, int gmLevel, int langID, string ip = "127.0.0.1")
         {
             Account Acct = GetAccount(username);
             if (Acct != null || _Codes.ContainsKey(username))

--- a/LauncherServer.Tests/LauncherPacketsTests.cs
+++ b/LauncherServer.Tests/LauncherPacketsTests.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Common;
+using FrameWork;
+using LauncherServer;
+using LauncherServer.Server;
+using LauncherServer.Server.Handler;
+using Xunit;
+
+namespace LauncherServer.Tests;
+
+public class LauncherPacketsTests
+{
+    private class MockAccountMgr : AccountMgr
+    {
+        public bool CheckIpResult { get; set; } = true;
+        public bool CreateAccountResult { get; set; } = true;
+        public LoginResult CheckAccountResult { get; set; } = LoginResult.LOGIN_SUCCESS;
+        public string TokenToReturn { get; set; } = "token";
+
+        public override bool CheckIp(string ip) => CheckIpResult;
+
+        public override bool CreateAccount(string username, string passwordHash, string email, int gmLevel, int langID, string ip = "127.0.0.1")
+            => CreateAccountResult;
+
+        public override LoginResult CheckAccount(string username, string passwordHash, string ip)
+            => CheckAccountResult;
+
+        public override LoginResult CheckAccount(string username, string passwordHash, string ip, out int accountId)
+        {
+            accountId = 0;
+            return CheckAccountResult;
+        }
+
+        public override string GenerateToken(string username) => TokenToReturn;
+    }
+
+    private class TestTCPManager : TCPManager
+    {
+        public TestTCPManager()
+        {
+            var field = typeof(TCPManager).GetField("m_packetBufPool", BindingFlags.NonPublic | BindingFlags.Instance);
+            var queue = new Queue<byte[]>();
+            for (int i = 0; i < 10; i++)
+                queue.Enqueue(new byte[BUF_SIZE]);
+            field!.SetValue(this, queue);
+        }
+    }
+
+    private class TestClient : Client
+    {
+        public byte[]? LastPacket { get; private set; }
+
+        public TestClient(TCPManager srv) : base(srv) { }
+
+        public override bool SendPacketNoBlock(PacketOut packet)
+        {
+            packet.WritePacketLength();
+            LastPacket = packet.ToArray();
+            return true;
+        }
+    }
+
+    private static PacketIn BuildCreatePacket(string username, string password, string email, byte langId)
+    {
+        var builder = new PacketOut((byte)Opcodes.CL_CREATE);
+        builder.WriteString(username);
+        builder.WriteString(password);
+        builder.WriteString(email);
+        builder.WriteByte(langId);
+        builder.WritePacketLength();
+        var data = builder.ToArray();
+        var packet = new PacketIn(data, 0, data.Length);
+        packet.Size = packet.GetUint32();
+        packet.Opcode = packet.GetUint8();
+        return packet;
+    }
+
+    private static PacketIn BuildStartPacket(string username, string password)
+    {
+        var builder = new PacketOut((byte)Opcodes.CL_START);
+        builder.WriteString(username);
+        builder.WriteString(password);
+        builder.WritePacketLength();
+        var data = builder.ToArray();
+        var packet = new PacketIn(data, 0, data.Length);
+        packet.Size = packet.GetUint32();
+        packet.Opcode = packet.GetUint8();
+        return packet;
+    }
+
+    private static PacketIn ParseResponse(byte[] data)
+    {
+        var packet = new PacketIn(data, 0, data.Length);
+        packet.Size = packet.GetUint32();
+        packet.Opcode = packet.GetUint8();
+        return packet;
+    }
+
+    private static TestClient CreateClient(MockAccountMgr mgr)
+    {
+        var tcp = new TestTCPManager();
+        var client = new TestClient(tcp);
+        typeof(BaseClient).GetField("_ip", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(client, "127.0.0.1:1234");
+        Core.AcctMgr = mgr;
+        return client;
+    }
+
+    [Fact]
+    public void CL_CREATE_Success_ReturnsSuccess()
+    {
+        var acctMgr = new MockAccountMgr { CheckIpResult = true, CreateAccountResult = true };
+        var client = CreateClient(acctMgr);
+        var packet = BuildCreatePacket("User1", "Pass123", "user@example.com", 1);
+
+        LauncherPackets.CL_CREATE(client, packet);
+
+        var response = ParseResponse(client.LastPacket!);
+        Assert.Equal((byte)Opcodes.LCR_CREATE, (byte)response.Opcode);
+        Assert.Equal((byte)CreteAccountResult.ACCOUNT_NAME_SUCCESS, response.GetUint8());
+        Core.AcctMgr = null;
+    }
+
+    [Fact]
+    public void CL_CREATE_Failure_ReturnsBusy()
+    {
+        var acctMgr = new MockAccountMgr { CheckIpResult = true, CreateAccountResult = false };
+        var client = CreateClient(acctMgr);
+        var packet = BuildCreatePacket("User1", "Pass123", "user@example.com", 1);
+
+        LauncherPackets.CL_CREATE(client, packet);
+
+        var response = ParseResponse(client.LastPacket!);
+        Assert.Equal((byte)Opcodes.LCR_CREATE, (byte)response.Opcode);
+        Assert.Equal((byte)CreteAccountResult.ACCOUNT_NAME_BUSY, response.GetUint8());
+        Core.AcctMgr = null;
+    }
+
+    [Fact]
+    public void CL_START_Success_ReturnsToken()
+    {
+        var acctMgr = new MockAccountMgr { CheckIpResult = true, CheckAccountResult = LoginResult.LOGIN_SUCCESS, TokenToReturn = "tok" };
+        var client = CreateClient(acctMgr);
+        var packet = BuildStartPacket("User1", "Pass123");
+
+        LauncherPackets.CL_START(client, packet);
+
+        var response = ParseResponse(client.LastPacket!);
+        Assert.Equal((byte)Opcodes.LCR_START, (byte)response.Opcode);
+        Assert.Equal((byte)LoginResult.LOGIN_SUCCESS, response.GetUint8());
+        Assert.Equal("tok", response.GetString());
+        Core.AcctMgr = null;
+    }
+
+    [Fact]
+    public void CL_START_Failure_ReturnsInvalid()
+    {
+        var acctMgr = new MockAccountMgr { CheckIpResult = true, CheckAccountResult = LoginResult.LOGIN_INVALID_USERNAME_PASSWORD };
+        var client = CreateClient(acctMgr);
+        var packet = BuildStartPacket("User1", "Pass123");
+
+        LauncherPackets.CL_START(client, packet);
+
+        var response = ParseResponse(client.LastPacket!);
+        Assert.Equal((byte)Opcodes.LCR_START, (byte)response.Opcode);
+        Assert.Equal((byte)LoginResult.LOGIN_INVALID_USERNAME_PASSWORD, response.GetUint8());
+        Assert.Equal(0, response.Remain());
+        Core.AcctMgr = null;
+    }
+}

--- a/LauncherServer.Tests/LauncherServer.Tests.csproj
+++ b/LauncherServer.Tests/LauncherServer.Tests.csproj
@@ -1,10 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../LauncherServer/Server/Handler/InputValidation.cs" Link="InputValidation.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LauncherServer\LauncherServer.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/LauncherServer/Core.cs
+++ b/LauncherServer/Core.cs
@@ -34,11 +34,16 @@ namespace LauncherServer
         public static FileInfo Info;
         public static string StrInfo;
 
+        private static AccountMgr _acctMgr;
         public static AccountMgr AcctMgr
         {
             get
             {
-                return Client.GetServerObject<AccountMgr>();
+                return _acctMgr ?? Client.GetServerObject<AccountMgr>();
+            }
+            set
+            {
+                _acctMgr = value;
             }
         }
 

--- a/ProjectWAR.sln
+++ b/ProjectWAR.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServerLauncher", "ServerLau
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Launcher", "Launcher\Launcher.csproj", "{C6981BF0-BE82-416A-8868-42F7B4E6B7F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LauncherServer.Tests", "LauncherServer.Tests\LauncherServer.Tests.csproj", "{C55E804F-7D74-4B40-B20F-843AA4A1A800}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -102,6 +104,14 @@ Global
 		{C6981BF0-BE82-416A-8868-42F7B4E6B7F6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C6981BF0-BE82-416A-8868-42F7B4E6B7F6}.Release|x64.ActiveCfg = Release|Any CPU
 		{C6981BF0-BE82-416A-8868-42F7B4E6B7F6}.Release|x64.Build.0 = Release|Any CPU
+		{C55E804F-7D74-4B40-B20F-843AA4A1A800}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C55E804F-7D74-4B40-B20F-843AA4A1A800}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C55E804F-7D74-4B40-B20F-843AA4A1A800}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C55E804F-7D74-4B40-B20F-843AA4A1A800}.Debug|x64.Build.0 = Debug|Any CPU
+		{C55E804F-7D74-4B40-B20F-843AA4A1A800}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C55E804F-7D74-4B40-B20F-843AA4A1A800}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C55E804F-7D74-4B40-B20F-843AA4A1A800}.Release|x64.ActiveCfg = Release|Any CPU
+		{C55E804F-7D74-4B40-B20F-843AA4A1A800}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- allow injecting mock account manager into launcher server core
- enable AccountMgr methods for overriding and add xUnit tests for CL_CREATE and CL_START
- reference LauncherServer from new test project and add to solution

## Testing
- `FrameworkPathOverride=/usr/lib/mono/4.8-api dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: Source file '/workspace/ProjectWAR/Common/Database/World/LiveEvents/LiveEventSubTask_Info.cs' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68abc6c3f8c08330984dac58a7313bcf