### PR TITLE
Include InputValidator in LauncherServer project

### DIFF
--- a/LauncherServer/LauncherServer.csproj
+++ b/LauncherServer/LauncherServer.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Core.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Server\Client.cs" />
+    <Compile Include="Server\Handler\InputValidation.cs" />
     <Compile Include="Server\Handler\Packets.cs" />
     <Compile Include="Server\Opcodes.cs" />
     <Compile Include="Server\PatcherFile.cs" />


### PR DESCRIPTION
## Summary
- add missing `InputValidation.cs` file to LauncherServer project so InputValidator is available

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68abd7fbcc6c8330ad000606b40a925a