### PR TITLE
Enable C# 10 compilation

### DIFF
--- a/AccountCacher/AccountCacher.csproj
+++ b/AccountCacher/AccountCacher.csproj
@@ -43,7 +43,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
@@ -52,7 +52,7 @@
     <Optimize>true</Optimize>
     <DebugType>none</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>none</ErrorReport>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -42,7 +42,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
@@ -51,7 +51,7 @@
     <Optimize>true</Optimize>
     <DebugType>none</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>none</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
@@ -108,7 +108,7 @@
     <Compile Include="Database\Character\Characters_mails.cs" />
     <Compile Include="Database\Character\Characters_quests.cs" />
     <Compile Include="Database\Character\Characters_socials.cs" />
-    <Compile Include="Database\Character\Characters_tok_kills.cs" />
+    <Compile Include="Database\Character\Characters_tok_Kills.cs" />
     <Compile Include="Database\Character\Characters_tok.cs" />
     <Compile Include="Database\Character\Characters_ability.cs" />
     <Compile Include="Database\Character\Characters_influence.cs" />
@@ -217,7 +217,7 @@
     <Compile Include="Database\World\Chapters\Tok_Info.cs" />
     <Compile Include="Database\World\Levels\Xp_Info.cs" />
     <Compile Include="Database\World\LiveEvents\LiveEventReward_Info.cs" />
-    <Compile Include="Database\World\LiveEvents\LiveEventSubTask_Info.cs" />
+    <Compile Include="Database\World\LiveEvents\LiveEventSubTask_info.cs" />
     <Compile Include="Database\World\LiveEvents\LiveEventTask_Info.cs" />
     <Compile Include="Database\World\LiveEvents\LiveEvent_Info.cs" />
     <Compile Include="Database\World\LootGroups\Loot_Group.cs" />

--- a/FrameWork/FrameWork.csproj
+++ b/FrameWork/FrameWork.csproj
@@ -22,7 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
@@ -31,7 +31,7 @@
     <Optimize>true</Optimize>
     <DebugType>none</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>none</ErrorReport>
     <WarningLevel>0</WarningLevel>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>

--- a/LauncherServer.Tests/LauncherServer.Tests.csproj
+++ b/LauncherServer.Tests/LauncherServer.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <IsPackable>false</IsPackable>
+    <LangVersion>10.0</LangVersion>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../LauncherServer/Server/Handler/InputValidation.cs" Link="InputValidation.cs" />

--- a/LauncherServer/LauncherServer.csproj
+++ b/LauncherServer/LauncherServer.csproj
@@ -43,7 +43,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
@@ -52,7 +52,7 @@
     <Optimize>true</Optimize>
     <DebugType>none</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>none</ErrorReport>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>

--- a/LobbyServer/LobbyServer.csproj
+++ b/LobbyServer/LobbyServer.csproj
@@ -43,7 +43,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
@@ -52,7 +52,7 @@
     <Optimize>true</Optimize>
     <DebugType>none</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
+      <LangVersion>10.0</LangVersion>
     <ErrorReport>none</ErrorReport>
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- upgrade projects to C# 10 language version
- align test project with x64 target and fix case-sensitive file paths

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj -c Debug` *(fails: The type 'Attribute' is defined in an assembly that is not referenced)*

------
https://chatgpt.com/codex/tasks/task_e_68abdd8450588330ac0045a2e4b2678c