### PR TITLE
Use dedicated lock object for GameClient packet handling

### DIFF
--- a/WorldServer/NetWork/GameClient.cs
+++ b/WorldServer/NetWork/GameClient.cs
@@ -29,6 +29,9 @@ namespace WorldServer.NetWork
         private CancellationTokenSource _logCts = null;
         private List<string> _packetLog = new List<string>();
 
+        // Lock to synchronize packet reception without locking on the GameClient instance itself.
+        private readonly object _receiveLock = new object();
+
         private CircularBuffer<object> _pLogBuf = new CircularBuffer<object>(100);
 
         public CircularBuffer<object> PLogBuf
@@ -202,7 +205,7 @@ namespace WorldServer.NetWork
             Log.Debug("HandlePacket", $"Packet...{packetBuffer.Length}");
             PacketIn inStream = new PacketIn(packetBuffer, 0, packetBuffer.Length, true, true);
 
-            lock (this)
+            lock (_receiveLock)
             {
                 long bufferLength = inStream.Length;
 


### PR DESCRIPTION
## Summary
- add private `_receiveLock` to GameClient to guard packet processing
- replace `lock(this)` with `lock(_receiveLock)` for safe synchronization

## Testing
- `dotnet test` *(fails: Microsoft.Cpp.Default.props not found, missing .NET Framework reference assemblies)*
- `xbuild WorldServer/WorldServer.csproj` *(fails: C# compiler does not support language version 10.0)*

------
https://chatgpt.com/codex/tasks/task_e_68abe610b44c8330be84eb3ae77b1f18