### PR TITLE
Fix random abs overflow and honor level boundaries

### DIFF
--- a/Common/FastRandom.cs
+++ b/Common/FastRandom.cs
@@ -27,17 +27,17 @@ namespace Common
 
         public int randomInt(int range)
         {
-            return fastAbs((int)randomLong() % range);
+            return (int)Math.Abs(randomLong() % range);
         }
 
         public int randomIntAbs()
         {
-            return fastAbs(randomInt());
+            return (int)Math.Abs((long)randomInt());
         }
 
         public int randomIntAbs(int range)
         {
-            return fastAbs(randomInt() % range);
+            return (int)Math.Abs((long)(randomInt() % range));
         }
 
         public double randomDouble()
@@ -98,7 +98,7 @@ namespace Common
 
         public static int fastAbs(int i)
         {
-            return (i >= 0) ? i : -i;
+            return i == int.MinValue ? int.MaxValue : Math.Abs(i);
         }
 
         public static float fastAbs(float d)
@@ -136,17 +136,17 @@ namespace Common
 
         public int randomInt(int range)
         {
-            return fastAbs((int)randomLong() % range);
+            return (int)Math.Abs(randomLong() % range);
         }
 
         public int randomIntAbs()
         {
-            return fastAbs(randomInt());
+            return (int)Math.Abs((long)randomInt());
         }
 
         public int randomIntAbs(int range)
         {
-            return fastAbs(randomInt() % range);
+            return (int)Math.Abs((long)(randomInt() % range));
         }
 
         public double randomDouble()
@@ -207,7 +207,7 @@ namespace Common
 
         public static int fastAbs(int i)
         {
-            return (i >= 0) ? i : -i;
+            return i == int.MinValue ? int.MaxValue : Math.Abs(i);
         }
 
         public static float fastAbs(float d)

--- a/Common/HonorCalculation.cs
+++ b/Common/HonorCalculation.cs
@@ -5,27 +5,24 @@ namespace Common
 {
     public class HonorCalculation
     {
-        private Dictionary<int, int> honorLevelReference = new Dictionary<int, int>();
+        private readonly List<(int Rank, int Threshold)> honorLevelReference = new()
+        {
+            (4, HONOR_RANK_4),
+            (3, HONOR_RANK_3),
+            (2, HONOR_RANK_2),
+            (1, HONOR_RANK_1)
+        };
         public const int HONOR_RANK_1 = 1000;
         public const int HONOR_RANK_2 = 2000;
         public const int HONOR_RANK_3 = 4000;
         public const int HONOR_RANK_4 = 8000;
 
-        public HonorCalculation()
-        {
-            // This list MUST be descending in sequence for this to work ;)
-            honorLevelReference.Add(4, HONOR_RANK_4);
-            honorLevelReference.Add(3, HONOR_RANK_3);
-            honorLevelReference.Add(2, HONOR_RANK_2);
-            honorLevelReference.Add(1, HONOR_RANK_1);
-        }
-
         public int GetHonorLevel(int honorPoints)
         {
-            foreach (var honorLevel in honorLevelReference)
+            foreach (var (rank, threshold) in honorLevelReference)
             {
-                if (honorLevel.Value < honorPoints)
-                    return honorLevel.Key;
+                if (honorPoints >= threshold)
+                    return rank;
             }
             return 0;
         }

--- a/LauncherServer.Tests/FastRandomTests.cs
+++ b/LauncherServer.Tests/FastRandomTests.cs
@@ -1,0 +1,31 @@
+using Common;
+using Xunit;
+
+namespace LauncherServer.Tests
+{
+    public class FastRandomTests
+    {
+        [Fact]
+        public void FastAbs_HandlesIntMinValue()
+        {
+            int result = FastRandom.fastAbs(int.MinValue);
+            Assert.True(result >= 0);
+        }
+
+        [Fact]
+        public void RandomIntAbs_NonNegative()
+        {
+            var rand = new FastRandom(12345);
+            for (int i = 0; i < 1000; i++)
+                Assert.True(rand.randomIntAbs() >= 0);
+        }
+
+        [Fact]
+        public void RandomIntAbsRange_NonNegative()
+        {
+            var rand = new FastRandom(54321);
+            for (int i = 0; i < 1000; i++)
+                Assert.True(rand.randomIntAbs(100) >= 0);
+        }
+    }
+}

--- a/LauncherServer.Tests/HonorCalculationTests.cs
+++ b/LauncherServer.Tests/HonorCalculationTests.cs
@@ -1,0 +1,21 @@
+using Common;
+using Xunit;
+
+namespace LauncherServer.Tests
+{
+    public class HonorCalculationTests
+    {
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(999, 0)]
+        [InlineData(HonorCalculation.HONOR_RANK_1, 1)]
+        [InlineData(HonorCalculation.HONOR_RANK_2, 2)]
+        [InlineData(HonorCalculation.HONOR_RANK_3, 3)]
+        [InlineData(HonorCalculation.HONOR_RANK_4, 4)]
+        public void CalculatesCorrectRank(int points, int expected)
+        {
+            var calc = new HonorCalculation();
+            Assert.Equal(expected, calc.GetHonorLevel(points));
+        }
+    }
+}

--- a/LauncherServer.Tests/LauncherServer.Tests.csproj
+++ b/LauncherServer.Tests/LauncherServer.Tests.csproj
@@ -7,9 +7,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\LauncherServer\LauncherServer.csproj" />
+    <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/WorldServer/NetWork/Handler/InterfaceHandlers.cs
+++ b/WorldServer/NetWork/Handler/InterfaceHandlers.cs
@@ -307,13 +307,14 @@ namespace WorldServer.NetWork.Handler
 
         private static string FindInvalidCharsInLastName(string lastName)
         {
-            // TODO: if special characters (like apostrophe) are allowed, then the name will need to be escaped before going into the db
-
             string result = "";
 
             for (int i = 0; i < lastName.Length; i++)
-                if (!char.IsLetter(lastName[i]))
-                    result = result + lastName[i];
+            {
+                char c = lastName[i];
+                if (!(char.IsLetter(c) || c == '\'' || c == '-'))
+                    result += c;
+            }
 
             return result;
         }

--- a/WorldServer/World/Objects/Player.cs
+++ b/WorldServer/World/Objects/Player.cs
@@ -2850,7 +2850,9 @@ namespace WorldServer.World.Objects
 
             UpdateLastName(lastName);
 
-            CharMgr.Database.SaveObject(Info);
+            // Persist using an escaped value to avoid SQL injection
+            string escaped = CharMgr.Database.Escape(lastName);
+            CharMgr.Database.ExecuteNonQuery($"UPDATE characters SET Surname='{escaped}' WHERE CharacterId={Info.CharacterId}");
         }
 
         private void UpdateLastName(string lastName)


### PR DESCRIPTION
## Summary
- prevent negative random values by casting to long and handling int.MinValue
- ensure honor levels use ordered thresholds and include boundary points
- allow apostrophes and hyphens in last names and escape before saving

## Testing
- `FrameworkPathOverride=/usr/lib/mono/4.8-api dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: The type 'Attribute' is defined in an assembly that is not referenced)*

------
https://chatgpt.com/codex/tasks/task_e_68abe7d4fc148330a6edd8629545ea48