### PR TITLE
Guard unsupported operations in ZOutputStream

### DIFF
--- a/FrameWork/zlib/ZOutputStream.cs
+++ b/FrameWork/zlib/ZOutputStream.cs
@@ -47,9 +47,13 @@ using System;
 namespace FrameWork
 {
 	
-	public class ZOutputStream:System.IO.Stream
-	{
-		private void  InitBlock()
+        /// <summary>
+        /// Stream that (de)compresses data and writes the result to an underlying stream.
+        /// This stream is write-only; read and seek operations are not supported.
+        /// </summary>
+        public class ZOutputStream:System.IO.Stream
+        {
+                private void  InitBlock()
 		{
 			flush_Renamed_Field = zlibConst.Z_NO_FLUSH;
 			buf = new byte[bufsize];
@@ -116,10 +120,10 @@ namespace FrameWork
 			Write(buf1, 0, 1);
 		}
 		//UPGRADE_TODO: The differences in the Expected value  of parameters for method 'WriteByte'  may cause compilation errors.  'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1092_3"'
-		public override  void  WriteByte(byte b)
-		{
-			WriteByte(b);
-		}
+                public override  void  WriteByte(byte b)
+                {
+                        WriteByte((int)b);
+                }
 		
 		public override void  Write(byte[] b1, int off, int len)
 		{
@@ -215,67 +219,69 @@ namespace FrameWork
 			out_Renamed.Flush();
 		}
 		//UPGRADE_TODO: The following method was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
-		public override int Read(byte[] buffer, int offset, int count)
-		{
-			return 0;
-		}
+                public override int Read(byte[] buffer, int offset, int count)
+                {
+                        throw new NotSupportedException("ZOutputStream is write-only");
+                }
 		//UPGRADE_TODO: The following method was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
-		public override void  SetLength(long value)
-		{
-		}
+                public override void  SetLength(long value)
+                {
+                        throw new NotSupportedException("ZOutputStream does not support SetLength");
+                }
 		//UPGRADE_TODO: The following method was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
-		public override long Seek(long offset, System.IO.SeekOrigin origin)
-		{
-			return 0;
-		}
+                public override long Seek(long offset, System.IO.SeekOrigin origin)
+                {
+                        throw new NotSupportedException("ZOutputStream does not support seeking");
+                }
 		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
 		public override bool CanRead
 		{
 			get
 			{
-				return false;
-			}
-			
-		}
+                                return false;
+                        }
+
+                }
 		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
 		public override bool CanSeek
 		{
 			get
 			{
-				return false;
-			}
-			
-		}
+                                return false;
+                        }
+
+                }
 		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
 		public override bool CanWrite
 		{
 			get
 			{
-				return false;
-			}
-			
-		}
+                                return true;
+                        }
+
+                }
 		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
 		public override long Length
 		{
 			get
 			{
-				return 0;
-			}
-			
-		}
+                                throw new NotSupportedException("ZOutputStream does not support Length");
+                        }
+
+                }
 		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
 		public override long Position
 		{
 			get
 			{
-				return 0;
-			}
-			
-			set
-			{
-			}
-			
-		}
-	}
+                                throw new NotSupportedException("ZOutputStream does not support Position");
+                        }
+
+                        set
+                        {
+                                throw new NotSupportedException("ZOutputStream does not support Position");
+                        }
+
+                }
+        }
 }

--- a/LauncherServer.Tests/LauncherServer.Tests.csproj
+++ b/LauncherServer.Tests/LauncherServer.Tests.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <ProjectReference Include="..\LauncherServer\LauncherServer.csproj" />
     <ProjectReference Include="..\Common\Common.csproj" />
+    <ProjectReference Include="..\FrameWork\FrameWork.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/LauncherServer.Tests/ZOutputStreamTests.cs
+++ b/LauncherServer.Tests/ZOutputStreamTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using FrameWork;
+using Xunit;
+
+namespace LauncherServer.Tests
+{
+    public class ZOutputStreamTests
+    {
+        [Fact]
+        public void Read_Throws_NotSupported()
+        {
+            using var stream = new ZOutputStream(new MemoryStream());
+            Assert.Throws<NotSupportedException>(() => stream.Read(Array.Empty<byte>(), 0, 0));
+        }
+
+        [Fact]
+        public void Seek_Throws_NotSupported()
+        {
+            using var stream = new ZOutputStream(new MemoryStream());
+            Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        }
+
+        [Fact]
+        public void SetLength_Throws_NotSupported()
+        {
+            using var stream = new ZOutputStream(new MemoryStream());
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(0));
+        }
+
+        [Fact]
+        public void Length_Throws_NotSupported()
+        {
+            using var stream = new ZOutputStream(new MemoryStream());
+            Assert.Throws<NotSupportedException>(() => { var _ = stream.Length; });
+        }
+
+        [Fact]
+        public void Position_Get_Throws_NotSupported()
+        {
+            using var stream = new ZOutputStream(new MemoryStream());
+            Assert.Throws<NotSupportedException>(() => { var _ = stream.Position; });
+        }
+
+        [Fact]
+        public void Position_Set_Throws_NotSupported()
+        {
+            using var stream = new ZOutputStream(new MemoryStream());
+            Assert.Throws<NotSupportedException>(() => stream.Position = 0);
+        }
+
+        [Fact]
+        public void CanProperties_ReportCorrectCapabilities()
+        {
+            using var stream = new ZOutputStream(new MemoryStream());
+            Assert.False(stream.CanRead);
+            Assert.True(stream.CanWrite);
+            Assert.False(stream.CanSeek);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- mark ZOutputStream as write-only and throw NotSupportedException for unsupported operations
- add unit tests covering unsupported Read/Seek/SetLength/Length/Position

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: The type 'Attribute' is defined in an assembly that is not referenced. You must add a reference to assembly 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.)*

------
https://chatgpt.com/codex/tasks/task_e_68abebbf97808330bde91142069bc50c