### PR TITLE
Fix honor level list initialization

### DIFF
--- a/Common/HonorCalculation.cs
+++ b/Common/HonorCalculation.cs
@@ -5,7 +5,7 @@ namespace Common
 {
     public class HonorCalculation
     {
-        private readonly List<(int Rank, int Threshold)> honorLevelReference = new()
+        private readonly List<(int Rank, int Threshold)> honorLevelReference = new List<(int Rank, int Threshold)>()
         {
             (4, HONOR_RANK_4),
             (3, HONOR_RANK_3),


### PR DESCRIPTION
## Summary
- Avoid target-typed `new()` for honor level thresholds to support older C# versions

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: reference assemblies for .NET Framework 4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac068ebdcc8330a91bae28cf0d12c0