### PR TITLE
Refactor random utilities and harden loot chest cleanup

### DIFF
--- a/Common/FastRandom.cs
+++ b/Common/FastRandom.cs
@@ -1,18 +1,18 @@
-﻿using System;
+using System;
 using System.Text;
 
 namespace Common
 {
-    public class FastRandom
+    internal struct FastRandomImpl
     {
         private long _seed;
 
-        public FastRandom(long seed)
+        public FastRandomImpl(long seed)
         {
             _seed = seed;
         }
 
-        private long randomLong()
+        private long RandomLong()
         {
             _seed ^= (_seed << 21);
             _seed ^= (_seed >> 35) & 0xFF;
@@ -20,54 +20,58 @@ namespace Common
             return _seed;
         }
 
-        public int randomInt()
+        public int RandomInt()
         {
-            return (int)randomLong();
+            return (int)RandomLong();
         }
 
-        public int randomInt(int range)
+        public int RandomInt(int range)
         {
-            return (int)Math.Abs(randomLong() % range);
+            if (range <= 0)
+                throw new ArgumentOutOfRangeException(nameof(range), "Range must be positive");
+            return (int)Math.Abs(RandomLong() % range);
         }
 
-        public int randomIntAbs()
+        public int RandomIntAbs()
         {
-            return (int)Math.Abs((long)randomInt());
+            return (int)Math.Abs((long)RandomInt());
         }
 
-        public int randomIntAbs(int range)
+        public int RandomIntAbs(int range)
         {
-            return (int)Math.Abs((long)(randomInt() % range));
+            if (range <= 0)
+                throw new ArgumentOutOfRangeException(nameof(range), "Range must be positive");
+            return (int)Math.Abs((long)(RandomInt() % range));
         }
 
-        public double randomDouble()
+        public double RandomDouble()
         {
-            return randomLong() / (long.MaxValue - 1d);
+            return RandomLong() / (long.MaxValue - 1d);
         }
 
-        public float randomFloat()
+        public float RandomFloat()
         {
-            return randomLong() / (long.MaxValue - 1f);
+            return RandomLong() / (long.MaxValue - 1f);
         }
 
-        public float randomPosFloat()
+        public float RandomPosFloat()
         {
-            return 0.5f * (randomFloat() + 1.0f);
+            return 0.5f * (RandomFloat() + 1.0f);
         }
 
-        public bool randomBoolean()
+        public bool RandomBoolean()
         {
-            return randomLong() > 0;
+            return RandomLong() > 0;
         }
 
-        public string randomCharacterString(int length)
+        public string RandomCharacterString(int length)
         {
             StringBuilder s = new StringBuilder(length);
 
             for (int i = 0; i < length; i++)
             {
-                bool upper = randomBoolean();
-                int letterIndex = randomIntAbs(26);
+                bool upper = RandomBoolean();
+                int letterIndex = RandomIntAbs(26);
                 char c = (char)((upper ? 'A' : 'a') + letterIndex);
                 s.Append(c);
             }
@@ -78,7 +82,7 @@ namespace Common
             return result;
         }
 
-        public double standNormalDistrDouble()
+        public double StandNormalDistrDouble()
         {
             double q = double.MaxValue;
             double u1 = 0;
@@ -86,138 +90,101 @@ namespace Common
 
             while (q >= 1d || q == 0)
             {
-                u1 = randomDouble();
-                u2 = randomDouble();
+                u1 = RandomDouble();
+                u2 = RandomDouble();
 
                 q = Math.Pow(u1, 2) + Math.Pow(u2, 2);
             }
 
-            double p = Math.Sqrt((-2d * (Math.Log(q))) / q);
+            double p = Math.Sqrt((-2d * Math.Log(q)) / q);
             return u1 * p;
         }
 
-        public static int fastAbs(int i)
+        public static int FastAbs(int i)
         {
             return i == int.MinValue ? int.MaxValue : Math.Abs(i);
         }
 
-        public static float fastAbs(float d)
+        public static float FastAbs(float d)
         {
-            return (d >= 0) ? d : -d;
+            return d >= 0 ? d : -d;
         }
 
-        public static double fastAbs(double d)
+        public static double FastAbs(double d)
         {
-            return (d >= 0) ? d : -d;
+            return d >= 0 ? d : -d;
         }
+    }
+
+    public class FastRandom
+    {
+        private FastRandomImpl _impl;
+
+        public FastRandom(long seed)
+        {
+            _impl = new FastRandomImpl(seed);
+        }
+
+        public int randomInt() => _impl.RandomInt();
+
+        public int randomInt(int range) => _impl.RandomInt(range);
+
+        public int randomIntAbs() => _impl.RandomIntAbs();
+
+        public int randomIntAbs(int range) => _impl.RandomIntAbs(range);
+
+        public double randomDouble() => _impl.RandomDouble();
+
+        public float randomFloat() => _impl.RandomFloat();
+
+        public float randomPosFloat() => _impl.RandomPosFloat();
+
+        public bool randomBoolean() => _impl.RandomBoolean();
+
+        public string randomCharacterString(int length) => _impl.RandomCharacterString(length);
+
+        public double standNormalDistrDouble() => _impl.StandNormalDistrDouble();
+
+        public static int fastAbs(int i) => FastRandomImpl.FastAbs(i);
+
+        public static float fastAbs(float d) => FastRandomImpl.FastAbs(d);
+
+        public static double fastAbs(double d) => FastRandomImpl.FastAbs(d);
     }
 
     public struct SFastRandom
     {
-        private long _seed;
+        private FastRandomImpl _impl;
 
         public SFastRandom(long seed)
         {
-            _seed = seed;
+            _impl = new FastRandomImpl(seed);
         }
 
-        private long randomLong()
-        {
-            _seed ^= (_seed << 21);
-            _seed ^= (_seed >> 35) & 0xFF;
-            _seed ^= (_seed << 4);
-            return _seed;
-        }
+        public int randomInt() => _impl.RandomInt();
 
-        public int randomInt()
-        {
-            return (int)randomLong();
-        }
+        public int randomInt(int range) => _impl.RandomInt(range);
 
-        public int randomInt(int range)
-        {
-            return (int)Math.Abs(randomLong() % range);
-        }
+        public int randomIntAbs() => _impl.RandomIntAbs();
 
-        public int randomIntAbs()
-        {
-            return (int)Math.Abs((long)randomInt());
-        }
+        public int randomIntAbs(int range) => _impl.RandomIntAbs(range);
 
-        public int randomIntAbs(int range)
-        {
-            return (int)Math.Abs((long)(randomInt() % range));
-        }
+        public double randomDouble() => _impl.RandomDouble();
 
-        public double randomDouble()
-        {
-            return randomLong() / (long.MaxValue - 1d);
-        }
+        public float randomFloat() => _impl.RandomFloat();
 
-        public float randomFloat()
-        {
-            return randomLong() / (long.MaxValue - 1f);
-        }
+        public float randomPosFloat() => _impl.RandomPosFloat();
 
-        public float randomPosFloat()
-        {
-            return 0.5f * (randomFloat() + 1.0f);
-        }
+        public bool randomBoolean() => _impl.RandomBoolean();
 
-        public bool randomBoolean()
-        {
-            return randomLong() > 0;
-        }
+        public string randomCharacterString(int length) => _impl.RandomCharacterString(length);
 
-        public string randomCharacterString(int length)
-        {
-            StringBuilder s = new StringBuilder(length);
+        public double standNormalDistrDouble() => _impl.StandNormalDistrDouble();
 
-            for (int i = 0; i < length; i++)
-            {
-                bool upper = randomBoolean();
-                int letterIndex = randomIntAbs(26);
-                char c = (char)((upper ? 'A' : 'a') + letterIndex);
-                s.Append(c);
-            }
+        public static int fastAbs(int i) => FastRandomImpl.FastAbs(i);
 
-            string result = s.ToString();
-            if (result.Length != length)
-                throw new InvalidOperationException("Generated string length does not match requested length");
-            return result;
-        }
+        public static float fastAbs(float d) => FastRandomImpl.FastAbs(d);
 
-        public double standNormalDistrDouble()
-        {
-            double q = double.MaxValue;
-            double u1 = 0;
-            double u2;
-
-            while (q >= 1d || q == 0)
-            {
-                u1 = randomDouble();
-                u2 = randomDouble();
-
-                q = Math.Pow(u1, 2) + Math.Pow(u2, 2);
-            }
-
-            double p = Math.Sqrt((-2d * (Math.Log(q))) / q);
-            return u1 * p;
-        }
-
-        public static int fastAbs(int i)
-        {
-            return i == int.MinValue ? int.MaxValue : Math.Abs(i);
-        }
-
-        public static float fastAbs(float d)
-        {
-            return (d >= 0) ? d : -d;
-        }
-
-        public static double fastAbs(double d)
-        {
-            return (d >= 0) ? d : -d;
-        }
+        public static double fastAbs(double d) => FastRandomImpl.FastAbs(d);
     }
 }

--- a/FrameWork/Database/Connection/MySqlDataConnection.cs
+++ b/FrameWork/Database/Connection/MySqlDataConnection.cs
@@ -165,9 +165,10 @@ namespace FrameWork
 
                         using (MySqlCommand cmd = new MySqlCommand(sqlcommand, (MySqlConnection)conn) { CommandTimeout = 180 })
                         {
-                            MySqlDataReader reader = cmd.ExecuteReader();
-                            callback(reader);
-                            reader.Close();
+                            using (MySqlDataReader reader = cmd.ExecuteReader())
+                            {
+                                callback(reader);
+                            }
 
                             Log.Debug("DataConnection", $"SQL Select ({isolation}) exec time {Environment.TickCount - start}ms");
 

--- a/FrameWork/zlib/ZOutputStream.cs
+++ b/FrameWork/zlib/ZOutputStream.cs
@@ -114,12 +114,11 @@ namespace FrameWork
 			compress = true;
 		}
 		
-		public  void  WriteByte(int b)
-		{
-			buf1[0] = (byte) b;
-			Write(buf1, 0, 1);
-		}
-		//UPGRADE_TODO: The differences in the Expected value  of parameters for method 'WriteByte'  may cause compilation errors.  'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1092_3"'
+                public  void  WriteByte(int b)
+                {
+                        buf1[0] = (byte) b;
+                        Write(buf1, 0, 1);
+                }
                 public override  void  WriteByte(byte b)
                 {
                         WriteByte((int)b);
@@ -218,61 +217,53 @@ namespace FrameWork
 		{
 			out_Renamed.Flush();
 		}
-		//UPGRADE_TODO: The following method was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
                 public override int Read(byte[] buffer, int offset, int count)
                 {
                         throw new NotSupportedException("ZOutputStream is write-only");
                 }
-		//UPGRADE_TODO: The following method was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
                 public override void  SetLength(long value)
                 {
                         throw new NotSupportedException("ZOutputStream does not support SetLength");
                 }
-		//UPGRADE_TODO: The following method was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
                 public override long Seek(long offset, System.IO.SeekOrigin origin)
                 {
                         throw new NotSupportedException("ZOutputStream does not support seeking");
                 }
-		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
-		public override bool CanRead
-		{
-			get
+                public override bool CanRead
+                {
+                        get
 			{
                                 return false;
                         }
 
                 }
-		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
-		public override bool CanSeek
-		{
-			get
+                public override bool CanSeek
+                {
+                        get
 			{
                                 return false;
                         }
 
                 }
-		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
-		public override bool CanWrite
-		{
-			get
+                public override bool CanWrite
+                {
+                        get
 			{
                                 return true;
                         }
 
                 }
-		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
-		public override long Length
-		{
-			get
+                public override long Length
+                {
+                        get
 			{
                                 throw new NotSupportedException("ZOutputStream does not support Length");
                         }
 
                 }
-		//UPGRADE_TODO: The following property was automatically generated and it must be implemented in order to preserve the class logic. 'ms-help://MS.VSCC.2003/commoner/redir/redirect.htm?keyword="jlca1232_3"'
-		public override long Position
-		{
-			get
+                public override long Position
+                {
+                        get
 			{
                                 throw new NotSupportedException("ZOutputStream does not support Position");
                         }

--- a/WorldServer/World/Objects/LootChest.cs
+++ b/WorldServer/World/Objects/LootChest.cs
@@ -99,36 +99,40 @@ namespace WorldServer.World.Objects
 
             try
             {
-                foreach (var lootBag in LootBags)
+                if (LootBags != null && LootBags.Count > 0)
                 {
-                    var character = CharMgr.GetCharacter(lootBag.Key, false);
-                    var characterName = character?.Name;
-
-                    // Forced to have some value here.
-                    if (Content == null)
-                        Content = "mail";
-                    if (String.IsNullOrEmpty(Content))
-                        Content = "mail";
-
-                    Character_mail mail = new Character_mail
+                    foreach (var lootBag in LootBags)
                     {
-                        Guid = CharMgr.GenerateMailGuid(),
-                        CharacterId = lootBag.Key,  //CharacterId
-                        SenderName = SenderName,
-                        ReceiverName = characterName,
-                        SendDate = (uint)TCPManager.GetTimeStamp(),
-                        Title = Title,
-                        Content = Content,
-                        Money = 0,
-                        Opened = false
-                    };
+                        var character = CharMgr.GetCharacter(lootBag.Key, false);
+                        var characterName = character?.Name;
 
-                    mail.CharacterIdSender = lootBag.Key;
-                    MailItem item = new MailItem((uint)lootBag.Value.Key.Entry, lootBag.Value.Value, 0, 0, (ushort)lootBag.Value.Value.Count);
-                    if (item != null)
-                    {
-                        mail.Items.Add(item);
-                        CharMgr.AddMail(mail);
+                        // Forced to have some value here.
+                        if (Content == null)
+                            Content = "mail";
+                        if (String.IsNullOrEmpty(Content))
+                            Content = "mail";
+
+                        Character_mail mail = new Character_mail
+                        {
+                            Guid = CharMgr.GenerateMailGuid(),
+                            CharacterId = lootBag.Key,  //CharacterId
+                            SenderName = SenderName,
+                            ReceiverName = characterName,
+                            SendDate = (uint)TCPManager.GetTimeStamp(),
+                            Title = Title,
+                            Content = Content,
+                            Money = 0,
+                            Opened = false
+                        };
+
+                        mail.CharacterIdSender = lootBag.Key;
+                        MailItem item = new MailItem((uint)lootBag.Value.Key.Entry, lootBag.Value.Value, 0, 0,
+                            (ushort)lootBag.Value.Value.Count);
+                        if (item != null)
+                        {
+                            mail.Items.Add(item);
+                            CharMgr.AddMail(mail);
+                        }
                     }
                 }
             }
@@ -156,14 +160,8 @@ namespace WorldServer.World.Objects
                     break;
             }
 
-            // Unknown if needed TODO
-            //GoldBag bag;
-
-            if (this.LootBags.ContainsKey(player.CharacterId))
+            if (LootBags != null && LootBags.TryGetValue(player.CharacterId, out var lootBag))
             {
-                KeyValuePair<Item_Info, List<Talisman>> lootBag;
-                this.LootBags.TryGetValue(player.CharacterId, out lootBag);
-
                 PacketOut Out = new PacketOut((byte)Opcodes.F_INTERACT_RESPONSE, 32);
                 Out.WriteByte(4);
                 Out.WriteByte(1);


### PR DESCRIPTION
## Summary
- consolidate random generators with shared implementation and add range validation
- guard loot chest mailing and interaction against null loot bags
- remove obsolete zlib upgrade comments
- ensure MySQL ExecuteSelect disposes readers

## Testing
- `dotnet test` *(fails: reference assemblies for .NETFramework v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6e318c74833094a58de62f7fa003