### PR TITLE
Ensure culture-invariant input validation

### DIFF
--- a/LauncherServer.Tests/InputValidationTests.cs
+++ b/LauncherServer.Tests/InputValidationTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using LauncherServer.Server.Handler;
 using Xunit;
 
@@ -14,9 +15,19 @@ namespace LauncherServer.Tests
         }
 
         [Theory]
+        [InlineData("abc")]
+        [InlineData("abcdefghijklmnopqrst")] // 20 characters
+        public void BoundaryUsernames_Pass(string username)
+        {
+            Assert.True(InputValidator.IsValidUsername(username));
+        }
+
+        [Theory]
         [InlineData("tooooooooooooooooooolongusername")]
         [InlineData("bad!user")]
         [InlineData("")]
+        [InlineData("ab")]
+        [InlineData("abcdefghijklmnopqrstu")] // 21 characters
         public void InvalidUsernames_Fail(string username)
         {
             Assert.False(InputValidator.IsValidUsername(username));
@@ -31,9 +42,19 @@ namespace LauncherServer.Tests
         }
 
         [Theory]
+        [InlineData("abcdef")]
+        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")] // 50 characters
+        public void BoundaryPasswords_Pass(string password)
+        {
+            Assert.True(InputValidator.IsValidPassword(password));
+        }
+
+        [Theory]
         [InlineData("short")]
         [InlineData("contains space")]
         [InlineData("bad\npass")]
+        [InlineData("abcde")]
+        [InlineData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")] // 51 characters
         public void InvalidPasswords_Fail(string password)
         {
             Assert.False(InputValidator.IsValidPassword(password));
@@ -54,6 +75,21 @@ namespace LauncherServer.Tests
         public void InvalidEmails_Fail(string email)
         {
             Assert.False(InputValidator.IsValidEmail(email));
+        }
+
+        [Fact]
+        public void UsernameValidation_IsCultureInvariant()
+        {
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+                Assert.True(InputValidator.IsValidUsername("validUser"));
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
         }
     }
 }

--- a/LauncherServer/Server/Handler/InputValidation.cs
+++ b/LauncherServer/Server/Handler/InputValidation.cs
@@ -8,9 +8,9 @@ namespace LauncherServer.Server.Handler
         // language versions. The previous implementation relied on C# 9's
         // target-typed `new()` expressions which are unavailable when the
         // project is compiled with the current language version setting (7.3).
-        private static readonly Regex UsernameRegex = new Regex("^[A-Za-z0-9_]{3,20}$", RegexOptions.Compiled);
-        private static readonly Regex PasswordRegex = new Regex("^[\x21-\x7E]{6,50}$", RegexOptions.Compiled);
-        private static readonly Regex EmailRegex = new Regex(@"^(([^<>()[\]\\.,;:\s@""']+(\.[^<>()[\]\\.,;:\s@""']+)*)|("".+""))@((\[[0-9]{1,3}(\.[0-9]{1,3}){3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$", RegexOptions.Compiled);
+        private static readonly Regex UsernameRegex = new Regex("^[A-Za-z0-9_]{3,20}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex PasswordRegex = new Regex("^[\x21-\x7E]{6,50}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+        private static readonly Regex EmailRegex = new Regex(@"^(([^<>()[\]\\.,;:\s@""']+(\.[^<>()[\]\\.,;:\s@""']+)*)|("".+""))@((\[[0-9]{1,3}(\.[0-9]{1,3}){3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         public static bool IsValidUsername(string username)
         {


### PR DESCRIPTION
## Summary
- make regex checks culture-invariant to prevent locale-specific behavior
- extend input validator tests with boundary cases and culture check

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c3135a88330952ebd01e0c3ee94