### PR TITLE
Simplify boolean comparisons and tidy enum declarations

### DIFF
--- a/Common/Database/World/Characters/CharacterInfo_renown.cs
+++ b/Common/Database/World/Characters/CharacterInfo_renown.cs
@@ -119,7 +119,7 @@ namespace Common
         public int Value
         {
             get { return _value; }
-            set { _value = value; ; }
+            set { _value = value; }
         }
     }
 }

--- a/FrameWork/Config/ConfigMgr.cs
+++ b/FrameWork/Config/ConfigMgr.cs
@@ -23,7 +23,7 @@ namespace FrameWork
                 foreach (Type type in assembly.GetTypes())
                 {
                     // Pick up a class
-                    if (type.IsClass != true)
+                    if (!type.IsClass)
                         continue;
 
                     object[] attrib = type.GetCustomAttributes(typeof(aConfigAttributes), true);

--- a/FrameWork/Config/Console/ConsoleMgr.cs
+++ b/FrameWork/Config/Console/ConsoleMgr.cs
@@ -117,7 +117,7 @@ namespace FrameWork
                 foreach (Type type in assembly.GetTypes())
                 {
                     // Pick up a class
-                    if (type.IsClass != true)
+                    if (!type.IsClass)
                         continue;
 
                     object[] attrib = type.GetCustomAttributes(typeof(ConsoleHandlerAttribute), true);
@@ -203,7 +203,7 @@ namespace FrameWork
 
         static bool GetBool(List<string> args)
         {
-            return GetInt(args) > 0 ? true : false;
+            return GetInt(args) > 0;
         }
 
         static string GetTotalString(List<string> args, int num)

--- a/FrameWork/Console/ConsoleMgr.cs
+++ b/FrameWork/Console/ConsoleMgr.cs
@@ -102,7 +102,7 @@ namespace FrameWork
                 {
                     Log.Dump("ConsoleMgr", "Attempting to load : " + type.FullName);
                     // Pick up a class
-                    if (type.IsClass != true)
+                    if (!type.IsClass)
                         continue;
 
                     object[] attrib = type.GetCustomAttributes(typeof(ConsoleHandlerAttribute), true);

--- a/FrameWork/Database/Connection/DataConnection.cs
+++ b/FrameWork/Database/Connection/DataConnection.cs
@@ -493,7 +493,7 @@ namespace FrameWork
         // Sauvegarde tous les changements effectué dans le dataset
         public virtual void SaveDataSet(string tableName, DataSet dataSet)
         {
-            if (dataSet.HasChanges() == false)
+            if (!dataSet.HasChanges())
                 return;
 
             switch (ConnectionType)

--- a/FrameWork/Database/DBManager.cs
+++ b/FrameWork/Database/DBManager.cs
@@ -82,7 +82,7 @@ namespace FrameWork
             {
                 foreach (Type type in assembly.GetTypes())
                 {
-                    if (type.IsClass != true)
+                    if (!type.IsClass)
                         continue;
 
                     try

--- a/FrameWork/Database/ObjectDatabase.cs
+++ b/FrameWork/Database/ObjectDatabase.cs
@@ -789,7 +789,7 @@ namespace FrameWork
                     Relation[] myAttributes = GetRelationAttributes(myMembers[i]);
                     if (myAttributes.Length > 0)
                     {
-                        if (myAttributes[0].AutoDelete == false)
+                        if (!myAttributes[0].AutoDelete)
                             continue;
 
                         bool array = false;
@@ -874,7 +874,7 @@ namespace FrameWork
                     {
                         Relation rel = myAttributes[0];
 
-                        if ((rel.AutoLoad == false) && autoload)
+                        if (!rel.AutoLoad && autoload)
                             continue;
 
                         bool isArray = false;

--- a/FrameWork/Loader/LoaderMgr.cs
+++ b/FrameWork/Loader/LoaderMgr.cs
@@ -43,7 +43,7 @@ namespace FrameWork
         private static void Load(List<LoadFunction> WaitEnd, HashSet<Type> loaded, Type type)
         {
             // Pick up a class
-            if (type.IsClass != true)
+            if (!type.IsClass)
                 return;
 
             if (loaded.Contains(type))

--- a/FrameWork/NetWork/Clients/BaseClient.cs
+++ b/FrameWork/NetWork/Clients/BaseClient.cs
@@ -231,7 +231,7 @@ namespace FrameWork
                 baseClient = (BaseClient)ar.AsyncState;
                 int numBytes = baseClient.Socket.EndReceive(ar);
 
-                if (numBytes > 0 || (numBytes <= 0 && DisconnectOnNullByte == false))
+                if (numBytes > 0 || (numBytes <= 0 && !DisconnectOnNullByte))
                 {
                     Log.Tcp(baseClient.GetIp(), baseClient.ReceiveBuffer, 0, numBytes);
 

--- a/FrameWork/NetWork/Clients/PacketOut.cs
+++ b/FrameWork/NetWork/Clients/PacketOut.cs
@@ -26,7 +26,7 @@ namespace FrameWork
     {
         OpcodeAndSize = 0x01,
         SizeAndOpcode = 0x02
-    };
+    }
 
     public class PacketOut : MemoryStream
     {
@@ -217,7 +217,7 @@ namespace FrameWork
 
         public long GetSize()
         {
-            long size = OpcodeInLen == false ? (Length - OpcodeLen) : Length;
+            long size = !OpcodeInLen ? (Length - OpcodeLen) : Length;
             if (!SizeInLen) size -= SizeLen;
             return size;
         }

--- a/FrameWork/NetWork/TCPManager.cs
+++ b/FrameWork/NetWork/TCPManager.cs
@@ -570,7 +570,7 @@ namespace FrameWork
                 foreach (Type type in assembly.GetTypes())
                 {
                     // Pick up a class
-                    if (type.IsClass != true)
+                    if (!type.IsClass)
                         continue;
 
                     foreach (MethodInfo m in type.GetMethods())
@@ -600,7 +600,7 @@ namespace FrameWork
                 foreach (Type type in assembly.GetTypes())
                 {
                     // Pick up a class
-                    if (type.IsClass != true)
+                    if (!type.IsClass)
                         continue;
 
                     CryptAttribute[] crypthandler =

--- a/Launcher/NetWork/Client.cs
+++ b/Launcher/NetWork/Client.cs
@@ -619,7 +619,7 @@ namespace Launcher
                 FileStream fileStream = File.Open("..\\data.myp", FileMode.Open, FileAccess.ReadWrite);
                 MYP myp = new MYP(MythicPackage.ART, (Stream)fileStream);
 
-                if (File.Exists(Application.StartupPath + "\\mythloginserviceconfig.xml") == false)
+                if (!File.Exists(Application.StartupPath + "\\mythloginserviceconfig.xml"))
                 {
                     _logger.Error("Missing file : mythloginserviceconfig.xml");
                     return;

--- a/Launcher/NetWork/PacketOut.cs
+++ b/Launcher/NetWork/PacketOut.cs
@@ -192,7 +192,7 @@ namespace Launcher
         {
             Position = 0;
 
-            long size = OpcodeInLen == false ? (Length - OpcodeLen) : Length;
+            long size = !OpcodeInLen ? (Length - OpcodeLen) : Length;
 
             if (!reversed)
             {

--- a/LauncherServer/Server/Opcodes.cs
+++ b/LauncherServer/Server/Opcodes.cs
@@ -136,14 +136,14 @@
         LAUNCHER_OK = 0x00,   // Le Launcher est ok
         LAUNCHER_VERSION = 0x01,   // Mauvaise version du launcher
         LAUNCHER_FILE = 0x02   // Fichier manquant dans le launcher
-    };
+    }
 
     public enum DownloadResult
     {
         SUCCESS = 0,
         INVALID_HASH = 1,
         FILE_CORRUPT = 2
-    };
+    }
 
     public enum Archive
     {

--- a/WorldServer/Managers/CharMgr.cs
+++ b/WorldServer/Managers/CharMgr.cs
@@ -253,7 +253,7 @@ namespace WorldServer.Managers
             if (PetOverrideStats.TryGetValue(careerLine, out infoOverrides))
             {
                 foreach (PetStatOverride ovr in infoOverrides)
-                    if (ovr.CareerLine == careerLine && ovr.Active == true)
+                    if (ovr.CareerLine == careerLine && ovr.Active)
                         overrides.Add(ovr);
 
                 overrides = overrides.OrderBy(x => x.PrimaryValue).ToList();
@@ -293,7 +293,7 @@ namespace WorldServer.Managers
             if (PetMasteryMods.TryGetValue(careerLine, out infoModifiers))
             {
                 foreach (PetMasteryModifiers mod in infoModifiers)
-                    if (mod.CareerLine == careerLine && mod.Active == true)
+                    if (mod.CareerLine == careerLine && mod.Active)
                         modifiers.Add(mod);
 
                 modifiers = modifiers.OrderBy(x => x.PrimaryValue).ToList();

--- a/WorldServer/Managers/CommandMgr.cs
+++ b/WorldServer/Managers/CommandMgr.cs
@@ -1270,7 +1270,7 @@ namespace WorldServer.Managers
                         }
                     }
                 }
-                if (PartyState == true) // is closed, must open
+                if (PartyState) // is closed, must open
                     PartyOpen(plr, text);
                 else
                     PartyClose(plr, text);
@@ -1405,7 +1405,7 @@ namespace WorldServer.Managers
                         unique = false;
                 }
 
-                if (unique == false)
+                if (!unique)
                 {
                     // Plr.SendLocalizeString("", ChatLogFilters.CHATLOGFILTERS_USER_ERROR, "Name already taken" );
                     return;

--- a/WorldServer/Managers/LootsMgr.cs
+++ b/WorldServer/Managers/LootsMgr.cs
@@ -64,7 +64,7 @@ namespace WorldServer.Managers
 
                 case 13:
                     TakeAll(player, false);
-                    if (crea != null && crea.Spawn.Proto.LairBoss == false) crea.IsActive = false;
+                    if (crea != null && !crea.Spawn.Proto.LairBoss) crea.IsActive = false;
                     break;
 
                 case 12:
@@ -72,15 +72,15 @@ namespace WorldServer.Managers
                         ClientUpdateLoot(player);
 
                     if (crea != null && LootCount < 1)
-                        if (crea != null && crea.Spawn.Proto.LairBoss == false) crea.IsActive = false;
+                        if (crea != null && !crea.Spawn.Proto.LairBoss) crea.IsActive = false;
                     break;
 
                 default:
                     ClientUpdateLoot(player);
 
                     if (crea != null && LootCount < 1)
-                        if (crea != null && crea.Spawn.Proto.LairBoss == false) crea.IsActive = false;
-                    break;
+                        if (crea != null && !crea.Spawn.Proto.LairBoss) crea.IsActive = false;
+            break;
             }
         }
 

--- a/WorldServer/Managers/WorldMgr.cs
+++ b/WorldServer/Managers/WorldMgr.cs
@@ -211,7 +211,7 @@ namespace WorldServer.Managers
                 if (Taxis[(byte)Plr.Realm].Info == null)
                     continue;
 
-                if (Taxis[(byte)Plr.Realm].Enable == false)
+                if (!Taxis[(byte)Plr.Realm].Enable)
                     continue;
 
                 if (Taxis[(byte)Plr.Realm].Tier > 0)
@@ -1087,7 +1087,7 @@ namespace WorldServer.Managers
             {
                 foreach (Type type in assembly.GetTypes())
                 {
-                    if (type.IsClass != true)
+                    if (!type.IsClass)
                         continue;
 
                     if (!type.IsSubclassOf(typeof(AGeneralScript)))
@@ -1497,7 +1497,7 @@ namespace WorldServer.Managers
             }
             var resultList = new List<BattlefieldObjective>();
             _logger.Debug($"Region = {regionMgr.RegionId} ObjectiveCount = {objectives.Count}");
-            foreach (BattleFront_Objective obj in objectives.Where(x => x.KeepSpawn == false))
+            foreach (BattleFront_Objective obj in objectives.Where(x => !x.KeepSpawn))
             {
                 BattlefieldObjective flag = new BattlefieldObjective(regionMgr, obj);
                 resultList.Add(flag);

--- a/WorldServer/NetWork/Handler/AuthentificationHandlers.cs
+++ b/WorldServer/NetWork/Handler/AuthentificationHandlers.cs
@@ -150,7 +150,7 @@ namespace WorldServer.NetWork.Handler
                 return;
 
             TCPServer server = (TCPServer)client.Server;
-            server.GetClientByAccount(cclient, cclient._Account.AccountId)?.Disconnect("F_DISCONNECT"); ;
+            server.GetClientByAccount(cclient, cclient._Account.AccountId)?.Disconnect("F_DISCONNECT");
         }
     }
 }

--- a/WorldServer/World/Abilities/AbilityInterface.cs
+++ b/WorldServer/World/Abilities/AbilityInterface.cs
@@ -735,7 +735,7 @@ namespace WorldServer.World.Abilities
                 _playerOwner._Value.MasterySkills = (0 + _bonusMasteryPoints[0]) + ";" +
                                                     (0 + _bonusMasteryPoints[1]) + ";" +
                                                     (0 + _bonusMasteryPoints[2]) + ";" +
-                                                    "0,0,0,0,0,0,0;0,0,0,0,0,0,0;0,0,0,0,0,0,0"; ;
+                                                    "0,0,0,0,0,0,0;0,0,0,0,0,0,0;0,0,0,0,0,0,0";
                 SaveMastery();
                 return;
             }

--- a/WorldServer/World/Abilities/CareerInterfaces/CareerInterface_Blackguard.cs
+++ b/WorldServer/World/Abilities/CareerInterfaces/CareerInterface_Blackguard.cs
@@ -74,7 +74,7 @@ namespace WorldServer.World.Abilities.CareerInterfaces
         public override bool AddResourceOverride(byte amount, bool blockEvent, bool noTimer)
         {
             Now = TCPManager.GetTimeStampMS();
-            if (noTimer == false)
+            if (!noTimer)
             {
                 if (Now < _nextOTimer)
                     return true;

--- a/WorldServer/World/Abilities/CareerInterfaces/CareerInterface_Ironbreaker.cs
+++ b/WorldServer/World/Abilities/CareerInterfaces/CareerInterface_Ironbreaker.cs
@@ -83,7 +83,7 @@ namespace WorldServer.World.Abilities.CareerInterfaces
         public override bool AddResourceOverride(byte amount, bool blockEvent, bool noTimer)
         {
             Now = TCPManager.GetTimeStampMS();
-            if (noTimer == false)
+            if (!noTimer)
             {
                 if (Now < _nextOTimer)
                     return true;

--- a/WorldServer/World/Abilities/CombatManager.cs
+++ b/WorldServer/World/Abilities/CombatManager.cs
@@ -86,7 +86,7 @@ namespace WorldServer.World.Abilities
                 /*
                 byte onehandweaponblockbonus = 0;
 
-                if (cmdInfo.AttackingStat == 1 && Caster.ItmInterface.Items[10] != null && Caster.ItmInterface.Items[10].Info.TwoHanded == false)
+                if (cmdInfo.AttackingStat == 1 && Caster.ItmInterface.Items[10] != null && !Caster.ItmInterface.Items[10].Info.TwoHanded)
                     onehandweaponblockbonus = 10;
                 */
 

--- a/WorldServer/World/Battlefronts/Apocalypse/Campaign.cs
+++ b/WorldServer/World/Battlefronts/Apocalypse/Campaign.cs
@@ -629,7 +629,7 @@ namespace WorldServer.World.Battlefronts.Apocalypse
             }
             try
             {
-                return ApocBattleFrontStatuses.Single(x => x.Locked == false);
+                return ApocBattleFrontStatuses.Single(x => !x.Locked);
             }
             catch (Exception e)
             {
@@ -1323,7 +1323,7 @@ namespace WorldServer.World.Battlefronts.Apocalypse
         private Tuple<LootChest, LootChest> PlaceChestsAtWarcampEntrances(Point3D orderWarcampEntrance, Point3D destructionWarcampEntrance)
         {
             LootChest orderLootChest = null;
-            LootChest destructionLootChest = null; ;
+            LootChest destructionLootChest = null;
 
             if (orderWarcampEntrance != null)
             {

--- a/WorldServer/World/Battlefronts/Keeps/BattleFrontKeep.cs
+++ b/WorldServer/World/Battlefronts/Keeps/BattleFrontKeep.cs
@@ -387,13 +387,13 @@ namespace WorldServer.World.Battlefronts.Keeps
                 h.CurrentWeapon?.Destroy();
 
             // Flip realm on Lord Kill
-            PendingRealm = Realm == Realms.REALMS_REALM_ORDER ? Realms.REALMS_REALM_DESTRUCTION : Realms.REALMS_REALM_ORDER; ;
+            PendingRealm = Realm == Realms.REALMS_REALM_ORDER ? Realms.REALMS_REALM_DESTRUCTION : Realms.REALMS_REALM_ORDER;
 
             _logger.Info($"Updating VP for Lord Kill. Pending Realm = {PendingRealm} {Info.Name}");
             WorldMgr.UpperTierCampaignManager.GetActiveCampaign().VictoryPointProgress.UpdateStatus(WorldMgr.UpperTierCampaignManager.GetActiveCampaign());
 
             // Find the lord in the Keep creatures.
-            var lord = Creatures.SingleOrDefault(x => x.Info.KeepLord == true);
+            var lord = Creatures.SingleOrDefault(x => x.Info.KeepLord);
             if (lord == null)
             {
                 _logger.Info($"Lord is NULL {Info.Name}");
@@ -1743,7 +1743,7 @@ namespace WorldServer.World.Battlefronts.Keeps
         /// </summary>
         public void CheckKeepPlayersInvolved()
         {
-            var lord = Creatures.SingleOrDefault(x => x.Info.KeepLord == true);
+            var lord = Creatures.SingleOrDefault(x => x.Info.KeepLord);
             if (lord == null)
                 _logger.Error($"Lord is null!!");
             else

--- a/WorldServer/World/Guild/Guild.cs
+++ b/WorldServer/World/Guild/Guild.cs
@@ -139,7 +139,7 @@ namespace WorldServer.World.Guild
         {
             foreach (KeyValuePair<Player, bool> invite in _invites)
             {
-                if (invite.Value == false)
+                if (!invite.Value)
                     return;
             }
 
@@ -945,8 +945,8 @@ namespace WorldServer.World.Guild
                 gev.End = end;
                 gev.Name = name;
                 gev.Description = description;
-                gev.Alliance = alliance == 1 ? true : false;
-                gev.Locked = locked == 1 ? true : false;
+                gev.Alliance = alliance == 1;
+                gev.Locked = locked == 1;
 
                 Info.Event.Add(freeslot, gev);
 
@@ -1085,8 +1085,8 @@ namespace WorldServer.World.Guild
                 events.End = end;
                 events.Name = name;
                 events.Description = description;
-                events.Alliance = alliance == 1 ? true : false;
-                events.Locked = locked == 1 ? true : false;
+                events.Alliance = alliance == 1;
+                events.Locked = locked == 1;
 
                 CharMgr.Database.SaveObject(events);
             }
@@ -1768,7 +1768,7 @@ namespace WorldServer.World.Guild
         public bool CanTakeFrom(Player player, int vaultIndex)
         {
             LogGuildBug(player);
-            GuildPermissions permission = GuildPermissions.GUILDPERMISSONS_VAULT1_TAKE_ITEM; ;
+            GuildPermissions permission = GuildPermissions.GUILDPERMISSONS_VAULT1_TAKE_ITEM;
 
             switch (vaultIndex)
             {

--- a/WorldServer/World/Interfaces/GatheringInterface.cs
+++ b/WorldServer/World/Interfaces/GatheringInterface.cs
@@ -150,7 +150,7 @@ namespace WorldServer.World.Interfaces
                         Realstat = true;
                 }
 
-                if (Realstat == false)
+                if (!Realstat)
                     return;
 
                 switch (Stat)

--- a/WorldServer/World/Interfaces/ItemsInterface.cs
+++ b/WorldServer/World/Interfaces/ItemsInterface.cs
@@ -3130,7 +3130,7 @@ namespace WorldServer.World.Interfaces
                     break;
 
                 case WeaponRequirements.TwoHander:
-                    if (GetItemInSlot((ushort)EquipSlot.MAIN_HAND) == null || GetItemInSlot((ushort)EquipSlot.MAIN_HAND).Info.TwoHanded == false)
+                    if (GetItemInSlot((ushort)EquipSlot.MAIN_HAND) == null || !GetItemInSlot((ushort)EquipSlot.MAIN_HAND).Info.TwoHanded)
                         result = AbilityResult.ABILITYRESULT_WRONG_WEAPON_TYPE;
                     break;
 

--- a/WorldServer/World/Interfaces/QuestsInterface.cs
+++ b/WorldServer/World/Interfaces/QuestsInterface.cs
@@ -886,7 +886,7 @@ namespace WorldServer.World.Interfaces
 
         public void SendQuests()
         {
-            List<Character_quest> quests = Quests.Values.ToList().FindAll(q => q.Done == false);
+            List<Character_quest> quests = Quests.Values.ToList().FindAll(q => !q.Done);
 
             PacketOut Out = new PacketOut((byte)Opcodes.F_QUEST_LIST, 1 + quests.Count * 14);
             Out.WriteByte((byte)quests.Count);

--- a/WorldServer/World/Objects/Player.cs
+++ b/WorldServer/World/Objects/Player.cs
@@ -4690,7 +4690,7 @@ namespace WorldServer.World.Objects
             float pullOffsetFactor;
 
             // Offset the pull by a random factor of between 5 and 15 feet of the caster's position.
-            if (fivefeetoverride == false)
+            if (!fivefeetoverride)
                 pullOffsetFactor = Math.Min(1f, (10f + StaticRandom.Instance.Next(10)) / GetDistanceToObject(caster));
             //if the 5 feet override is true then set it to 5 feet instead.
             else
@@ -5580,7 +5580,7 @@ namespace WorldServer.World.Objects
 
         public void SetPVPFlag(bool state)
         {
-            if (state == false)
+            if (!state)
                 Faction = (byte)(Realm == Realms.REALMS_REALM_DESTRUCTION ? 8 : 6);
             else
                 Faction = (byte)(Realm == Realms.REALMS_REALM_DESTRUCTION ? 72 : 68);

--- a/WorldServer/World/Scenarios/DominationScenarioEC.cs
+++ b/WorldServer/World/Scenarios/DominationScenarioEC.cs
@@ -70,7 +70,7 @@ namespace WorldServer.World.Scenarios
             base.OnStart();
             foreach (var obj in Region.Objects.Where(e => e != null).ToList())
             {
-                Log.Info("Scenario", "Object " + obj.ToString() + " WorldPos " + obj.WorldPosition.ToString()); ;
+                Log.Info("Scenario", "Object " + obj.ToString() + " WorldPos " + obj.WorldPosition.ToString());
             }
             Random r = new Random();
             EvtInterface.AddEvent(WindsOfChange, r.Next(15000, 40000), 1);

--- a/WorldServer/World/Scripting/PublicQuests/Destro/DeathstoneQuarry.cs
+++ b/WorldServer/World/Scripting/PublicQuests/Destro/DeathstoneQuarry.cs
@@ -58,7 +58,7 @@ namespace WorldServer.World.Scripting.PublicQuests.Destro
         {
             int X = Obj.WorldPosition.X;
             int Y = Obj.WorldPosition.Y;
-            int Z = Obj.WorldPosition.Z; ;
+            int Z = Obj.WorldPosition.Z;
             ushort O = Obj.Heading;
 
             Creature_proto Proto = CreatureService.GetCreatureProto(14872);


### PR DESCRIPTION
## Summary
- replace verbose `== true/false` checks with direct boolean logic across database, network, and gameplay modules for clarity
- remove stray semicolons after enum declarations in PacketOut and Opcodes to align with C# conventions
- streamline boolean helpers by dropping redundant `? true : false` ternaries in guild events and console parsing

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac81b7acf88330ae3aacefe5317021