### PR TITLE
Enable nullable context in LauncherPacketsTests

### DIFF
--- a/LauncherServer.Tests/LauncherPacketsTests.cs
+++ b/LauncherServer.Tests/LauncherPacketsTests.cs
@@ -8,6 +8,8 @@ using LauncherServer.Server.Handler;
 using LauncherOpcodes = LauncherServer.Server.Opcodes;
 using Xunit;
 
+#nullable enable
+
 namespace LauncherServer.Tests;
 
 public class LauncherPacketsTests


### PR DESCRIPTION
## Summary
- enable nullable annotations in LauncherPacketsTests to allow use of nullable references

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9d6d15a4833096a8466956558c36