### PR TITLE
Add win-x64 runtime and fix test assembly info

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,9 @@
     <BaseOutputPath>$(MSBuildThisFileDirectory)build/bin/</BaseOutputPath>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)build/obj/</BaseIntermediateOutputPath>
     <PlatformTarget>x64</PlatformTarget>
-    <RuntimeIdentifiers>win</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/LauncherServer.Tests/LauncherServer.Tests.csproj
+++ b/LauncherServer.Tests/LauncherServer.Tests.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <LangVersion>10.0</LangVersion>
     <PlatformTarget>x64</PlatformTarget>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\LauncherServer\LauncherServer.csproj" />
@@ -15,7 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/LauncherServer.Tests/Properties/AssemblyInfo.cs
+++ b/LauncherServer.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("LauncherServer.Tests")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LauncherServer.Tests")]
+[assembly: ComVisible(false)]
+[assembly: Guid("cf1f8144-e3d1-45b7-8354-bdc59b233217")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
## Summary
- set runtime identifier to win-x64 in shared build properties
- include .NET Framework reference assemblies to support cross-platform builds
- disable autogenerated assembly attributes for tests and add explicit AssemblyInfo

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: The reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca32eabf4833094e1b74633072bfe