### PR TITLE
Replace NLog with stub logger and fix assembly metadata

### DIFF
--- a/Launcher/Launcher.csproj
+++ b/Launcher/Launcher.csproj
@@ -130,6 +130,7 @@
     <Compile Include="NetWork\PacketIn.cs" />
     <Compile Include="NetWork\PacketOut.cs" />
     <Compile Include="Patcher.cs" />
+    <Compile Include="NLogStub.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <EmbeddedResource Include="ApocLauncher.resx">
@@ -152,9 +153,6 @@
     <None Include="NLog.xsd">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
     </None>
   </ItemGroup>
   <ItemGroup>
@@ -193,9 +191,6 @@
     <Content Include="WAR.ico" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NLog">
-      <Version>6.0.3</Version>
-    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Launcher/NLogStub.cs
+++ b/Launcher/NLogStub.cs
@@ -1,0 +1,24 @@
+namespace NLog
+{
+    public class Logger
+    {
+        private readonly string _name;
+        public Logger(string name) => _name = name;
+        public void Trace(string message) => System.Console.WriteLine($"TRACE [{_name}] {message}");
+        public void Debug(string message) => System.Console.WriteLine($"DEBUG [{_name}] {message}");
+        public void Info(string message) => System.Console.WriteLine($"INFO [{_name}] {message}");
+        public void Warn(string message) => System.Console.WriteLine($"WARN [{_name}] {message}");
+        public void Error(string message) => System.Console.WriteLine($"ERROR [{_name}] {message}");
+    }
+
+    public static class LogManager
+    {
+        public static Logger GetCurrentClassLogger()
+        {
+            var frame = new System.Diagnostics.StackFrame(1, false);
+            var type = frame.GetMethod()?.DeclaringType;
+            string name = type != null ? type.FullName ?? "Unknown" : "Unknown";
+            return new Logger(name);
+        }
+    }
+}

--- a/Launcher/packages.config
+++ b/Launcher/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NLog" version="5.3.2" targetFramework="net48" />
-</packages>

--- a/LauncherServer.Tests/LauncherServer.Tests.csproj
+++ b/LauncherServer.Tests/LauncherServer.Tests.csproj
@@ -5,6 +5,7 @@
     <LangVersion>10.0</LangVersion>
     <PlatformTarget>x64</PlatformTarget>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\LauncherServer\LauncherServer.csproj" />

--- a/LauncherServer.Tests/Properties/AssemblyInfo.cs
+++ b/LauncherServer.Tests/Properties/AssemblyInfo.cs
@@ -1,10 +1,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("LauncherServer.Tests")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("LauncherServer.Tests")]
+// Only include attributes that are not generated automatically to avoid
+// duplicate assembly metadata during compilation.
 [assembly: ComVisible(false)]
 [assembly: Guid("cf1f8144-e3d1-45b7-8354-bdc59b233217")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
## Summary
- replace missing NLog dependency with an in-repo stub logger
- remove duplicate assembly attributes from LauncherServer.Tests

## Testing
- `dotnet build Launcher/Launcher.csproj` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: reference assemblies for .NETFramework,Version=v4.8 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca7e7f794833088dcde57223e25b9