### PR TITLE
Fix .NET reference assembly lookup for tests

### DIFF
--- a/Common/packages.config
+++ b/Common/packages.config
@@ -4,4 +4,5 @@
   <package id="FakeItEasy" version="8.3.0" targetFramework="net48" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net48" />
   <package id="xunit.extensibility.core" version="2.9.3" targetFramework="net48" />
+  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.3" targetFramework="net48" developmentDependency="true" />
 </packages>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,9 @@
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)build/obj/</BaseIntermediateOutputPath>
     <PlatformTarget>x64</PlatformTarget>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <TargetFrameworkRootPath>$(NuGetPackageRoot)microsoft.netframework.referenceassemblies.net48/1.0.3/build/</TargetFrameworkRootPath>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- reference .NET Framework assemblies via the Microsoft.NETFramework.ReferenceAssemblies package
- remove bundled .NET Framework reference assemblies from the repository

## Testing
- `dotnet test LauncherServer.Tests/LauncherServer.Tests.csproj` *(fails: CS0246 The type or namespace name 'InlineDataAttribute' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68acd5877df8833090862721772d2e1a