### PR TITLE
chore: ignore compiled build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Ignore build and compiled artifacts
+bin/
+obj/
+*.dll
+*.exe
+*.pdb
+*.cache
+*.log
+
+# Visual Studio local settings
+.vs/
+*.o
+*.obj
+*.so
+*.dylib
+*.lib
+
+# Dependency directories
+packages/
+deps/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Guidelines
+
+This repository follows seven common programming principles. Adhere to them when writing or reviewing code:
+
+1. **KISS (Keep It Simple, Stupid)** – favor straightforward, easy-to-understand solutions.
+2. **DRY (Don't Repeat Yourself)** – avoid duplicating logic; reuse abstractions instead.
+3. **YAGNI (You Aren't Gonna Need It)** – implement only what is necessary for current requirements.
+4. **SOLID** – design code with single responsibility, open/closed, Liskov substitution, interface segregation, and dependency inversion in mind.
+5. **Separation of Concerns (SoC)** – keep different responsibilities in distinct modules.
+6. **Avoid Premature Optimization** – optimize only after measuring and identifying bottlenecks.
+7. **Law of Demeter** – components should only talk to their direct collaborators and expose minimal interfaces.
+
+Use these principles to guide your design, implementation, and reviews.


### PR DESCRIPTION
## Summary
- extend `.gitignore` to cover dependency directories
- document seven programming principles in `AGENTS.md`

## Testing
- `dotnet test` *(fails: The imported project "/Microsoft.Cpp.Default.props" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0a19df3c83309fb1768362ff99a4