### PR TITLE
Fix WarhammerOnlineHash reference path

### DIFF
--- a/Launcher/Launcher.csproj
+++ b/Launcher/Launcher.csproj
@@ -110,7 +110,7 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="WarhammerOnlineHash, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\EasyMyp\WarhammerOnlineHash.dll</HintPath>
+      <HintPath>..\deps\EasyMyp\WarhammerOnlineHash.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- correct WarhammerOnlineHash.dll hint path in the Launcher project

## Testing
- `xbuild Launcher/Launcher.csproj` *(fails: CSC: error CS1617 invalid -langversion option `7.3`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad11aa37888330a8b02f407fd654c2