### PR TITLE
Fix public quest stages failing to spawn, hanging, and showing a 0.00 reset timer

### DIFF
--- a/WorldServer/World/Battlefronts/Keeps/KeepCommunications.cs
+++ b/WorldServer/World/Battlefronts/Keeps/KeepCommunications.cs
@@ -32,7 +32,9 @@ namespace WorldServer.World.Battlefronts.Keeps
                 Out.WriteByte((byte)doors.Count);
                 Out.WriteByte(keep.Rank); // Rank
                 if (doors.Count > 0)
-                    if (innerDoor != null)
+                    // GameObject is only created when the door is spawned into the region, which
+                    // has not happened during startup keep locking - hence the extra null check.
+                    if (innerDoor?.GameObject != null)
                         Out.WriteByte((byte)((innerDoor.GameObject.PctHealth))); // Door health
                     else
                     {

--- a/WorldServer/World/Objects/PublicQuests/PQuestObjective.cs
+++ b/WorldServer/World/Objects/PublicQuests/PQuestObjective.cs
@@ -99,8 +99,14 @@ namespace WorldServer.World.Objects.PublicQuests
                     GameObject_proto Proto = GameObjectService.GetGameObjectProto(spawn.Entry);
                     if (Proto == null)
                     {
-                        Log.Error("PQGO", "No Proto");
-                        return;
+                        // Skip only this spawn. Previously this returned, which abandoned the
+                        // entire remaining spawn list for the objective: because spawns are
+                        // processed in list order, a single unknown gameobject proto silently
+                        // prevented every creature listed after it from spawning. The Type 1
+                        // branch above already uses continue for the equivalent case.
+                        Log.Error("PQGO", "No Proto for gameobject entry " + spawn.Entry
+                                  + " (objective " + spawn.Objective + ") - skipping this spawn");
+                        continue;
                     }
 
                     GameObject_spawn S = new GameObject_spawn();

--- a/WorldServer/World/Objects/PublicQuests/PublicQuest.cs
+++ b/WorldServer/World/Objects/PublicQuests/PublicQuest.cs
@@ -21,6 +21,12 @@ namespace WorldServer.World.Objects.PublicQuests
         public List<PQuestStage> Stages;
 
         private const ushort TIME_PQ_RESET = 180;
+
+        /// <summary>
+        /// Extra seconds added to a PROTECT_UNIT stage's failure timer. The protect credit
+        /// fires at exactly Stage.Time, so the failure backstop must land strictly after it.
+        /// </summary>
+        private const ushort PROTECT_FAIL_GRACE = 30;
         private const ushort TIME_DUNGEON_RESET = 28800;
         private const ushort TIME_EACH_STAGE = 540;
 
@@ -657,9 +663,22 @@ namespace WorldServer.World.Objects.PublicQuests
                 {
                     Stage = sStage;
                     Stage.Reset();
-                    _stageTimeEnd = TCPManager.GetTimeStamp() + ((Stage.Time > 0 ? Stage.Time : TIME_EACH_STAGE));
-                    if (sStage.Objectives.First().Objective.Type != (byte)Objective_Type.QUEST_PROTECT_UNIT)
-                        EvtInterface.AddEvent(Failed, (Stage.Time > 0 ? Stage.Time : TIME_EACH_STAGE) * 1000, 1);
+                    // PROTECT_UNIT stages originally got no Failed event at all, so a dead
+                    // protected unit hung the stage forever - it could neither complete
+                    // (credit comes from PQuestCreature.Protected(), which never fires once
+                    // the unit is dead) nor time out.
+                    //
+                    // The timer cannot simply be armed at Stage.Time: PQuestStage.Time is
+                    // copied from PQuest_Objective.Time (see the constructor above), which is
+                    // the SAME value the protect credit fires on - arming it there makes
+                    // failure race completion at the identical instant. The grace period
+                    // makes it a backstop instead, so a surviving unit always wins.
+                    int failSeconds = (Stage.Time > 0 ? Stage.Time : TIME_EACH_STAGE);
+                    if (sStage.Objectives.First().Objective.Type == (byte)Objective_Type.QUEST_PROTECT_UNIT)
+                        failSeconds += PROTECT_FAIL_GRACE;
+
+                    _stageTimeEnd = TCPManager.GetTimeStamp() + failSeconds;
+                    EvtInterface.AddEvent(Failed, failSeconds * 1000, 1);
 
                     foreach (uint Plr in ActivePlayers)
                     {
@@ -792,6 +811,14 @@ namespace WorldServer.World.Objects.PublicQuests
         {
             EvtInterface.RemoveEvent(Failed);
             EvtInterface.AddEvent(Reset, TIME_PQ_RESET * 1000, 1);
+
+            // The client's countdown is rendered from (_stageTimeEnd - now) in
+            // SendCurrentStage. End() refreshes it when scheduling Reset; Failed()
+            // did not, so after a failure the field still held the already-elapsed
+            // stage deadline and the UI showed "resetting in 0.00" for the whole
+            // 180s wait. The Reset event itself was always scheduled correctly -
+            // this only corrects what the player is shown.
+            _stageTimeEnd = TCPManager.GetTimeStamp() + TIME_PQ_RESET;
             _started = false;
             _ended = true;
             Stage.Cleanup();


### PR DESCRIPTION
Four related fixes to the public quest system, found while bringing a local server up against the published database.

### 1. `PQuestObjective.Reset()` — one bad row aborts the whole stage

When a Type 2 spawn's gameobject proto was missing, the method `return`ed instead of skipping the row. Spawns are iterated in list order, so a single unknown entry silently prevented **every creature listed after it** from spawning.

The visible symptom is a stage that comes up with a partial mob set, no in-game error, and no corpses — including cases where the mob required to complete the stage is the one that never appears. The Type 1 branch immediately above already used `continue` for the equivalent case; this makes the two consistent.

The log line now names the entry and objective, so the underlying data gap is diagnosable rather than silent.

### 2. `PublicQuest.AdvanceToNextStage()` — `QUEST_PROTECT_UNIT` stages could hang forever

Protect stages were excluded from arming the `Failed` event. If the protected unit died, the stage could neither complete — credit comes from `PQuestCreature.Protected()`, which never fires once the unit is dead — nor time out. The quest stayed stuck until a GM ran `.pq reset`.

The timer can't simply be armed at `Stage.Time`: `PQuestStage.Time` is copied from `PQuest_Objective.Time` in the constructor, which is the *same* value the protect credit fires on, so arming it there makes failure race completion at the identical instant. `PROTECT_FAIL_GRACE` turns it into a backstop so a surviving unit always wins.

### 3. `PublicQuest.Failed()` — client showed "resetting in 0.00"

`Failed()` scheduled `Reset` correctly but never refreshed `_stageTimeEnd`, which is what `SendCurrentStage` renders as the countdown. `End()` already does this. Without it the field still held the already-elapsed stage deadline, so the client displayed `0.00` for the entire `TIME_PQ_RESET` wait. Behaviour was correct; only the display was wrong.

### 4. `KeepCommunications.SendKeepStatus()` — NRE during startup keep locking

`innerDoor.GameObject` is only created once a door is spawned into its region, so it is null while keeps are locked at startup. `innerDoor` was already null-checked; this extends the guard to its `GameObject`.

### Testing

Verified on a local server against the published `war_world` dump:

- Before: PQ 165 (Raven Host Vanguard) stage II spawned 8 of 20 creatures, omitting Father Sigwald — the protected unit — because two Type 2 entries earlier in its list have no gameobject proto. The stage was unwinnable.
- After: the full spawn set appears and the stage completes normally.
- Failure path exercised by letting the protected unit die: the stage now fails and resets with a correct countdown instead of hanging.

Changes are limited to those four sites; no configuration or data files are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
