### PR TITLE
Fix battlefield objectives never completing capture, and PQ timers following players

### DIFF
--- a/WorldServer/Managers/Commands/CampaignCommands.cs
+++ b/WorldServer/Managers/Commands/CampaignCommands.cs
@@ -44,6 +44,25 @@ namespace WorldServer.Managers.Commands
                 DisplayKeepStatus(orderKeep, plr);
         }
 
+        [CommandAttribute(EGmLevel.AnyGM, "Diagnostic for the battlefield objective you are standing at. Usage: .campaign objdiag")]
+        public static void ObjDiag(Player plr, string targetString = null)
+        {
+            // BattlefieldObjective.SendDiagnostic() already existed but nothing called it -
+            // ".campaign diag" reports campaign/keep status only, so there was no way to see
+            // an objective's actual state, owner or capture/secure progress in game.
+            // CurrentObjectiveFlag is assigned in BattlefieldObjective.AddInRange.
+            var flag = plr.CurrentObjectiveFlag;
+            if (flag == null)
+            {
+                SendCsr(plr, "Not in range of a battlefield objective.");
+                return;
+            }
+
+            flag.SendDiagnostic(plr);
+            plr.SendClientMessage($"DisplayedTimer: {flag.DisplayedTimer}");
+            plr.SendClientMessage($"CaptureTimer: {flag.CaptureTimer}  GuardedTimer: {flag.GuardedTimer}  now: {TCPManager.GetTimeStamp()}");
+        }
+
         private static void DisplayKeepStatus(BattleFrontKeep keep, Player plr)
         {
             plr.SendClientMessage($"Keep Status : {keep.KeepStatus}");

--- a/WorldServer/World/Battlefronts/Apocalypse/BattlefieldObjective.cs
+++ b/WorldServer/World/Battlefronts/Apocalypse/BattlefieldObjective.cs
@@ -203,10 +203,24 @@ namespace WorldServer.World.Battlefronts.Apocalypse
         {
             var currentTime = TCPManager.GetTimeStamp();
 
+            // Both timers are one-shot: clear before firing. Neither SetObjectiveCaptured
+            // nor SetObjectiveGuarded reset them, so once a timer elapsed it stayed
+            // elapsed and this re-fired its command every second forever. The follow-up
+            // fires land in a state that has no transition for them (e.g.
+            // OnCaptureTimerEnd while already Captured), and because the state machine
+            // has no exception listener registered that raises out of CheckTimers once
+            // per second - leaving the objective stuck showing HOLD at 0:00 and never
+            // progressing to Guarded.
             if (CaptureTimer > 0 && CaptureTimer <= currentTime)
+            {
+                CaptureTimer = 0;
                 OnCapturedTimerEnd();
+            }
             if (GuardedTimer > 0 && GuardedTimer <= currentTime)
+            {
+                GuardedTimer = 0;
                 OnGuardedTimerEnd();
+            }
 
             DisplayedTimer--;
             if (DisplayedTimer <= 0)

--- a/WorldServer/World/Objects/Player.cs
+++ b/WorldServer/World/Objects/Player.cs
@@ -6267,9 +6267,17 @@ namespace WorldServer.World.Objects
 
             if (CurrentPQArea != pqarea)
             {
+                // Drop public quest membership on ANY area change, not only when moving
+                // into the "no PQ" sentinel area (31). Previously, walking from one PQ
+                // area straight into another - or into any area with no matching PQ -
+                // left the player registered with the old quest, so its stage timer kept
+                // being sent to them long after they had left. RemovePlayer also emits
+                // F_OBJECTIVE_UPDATE with 0, which clears the tracker on the client.
+                // Re-adding happens below when the new area actually maps to a PQ.
+                QtsInterface.PublicQuest?.RemovePlayer(this, false);
+
                 if (pqarea == 31)
                 {
-                    QtsInterface.PublicQuest?.RemovePlayer(this, false);
                     CurrentKeep?.RemovePlayer(this);
                 }
                 else if (pqarea > 28)  // keeps


### PR DESCRIPTION
Three related fixes found while testing RvR on a local server. Independent of #176.

### 1. `BattlefieldObjective.CheckTimers()` — objectives never finish capturing

`CaptureTimer` and `GuardedTimer` are never reset once they elapse. Neither `SetObjectiveCaptured` nor `SetObjectiveGuarded` clears them, and `CheckTimers` runs once a second firing on `timer <= now` — so an elapsed timer re-fires its command **every second, indefinitely**.

Those repeat fires land in a state with no transition for them (e.g. `OnCaptureTimerEnd` while already `Captured`). The state machine registers no exception listener, so that raises out of `CheckTimers` once per second and the objective never progresses to `Guarded` — it sits displaying its capture state at `0:00`.

Both timers are now cleared before firing, making them one-shot as the code already intends: each is set fresh in `SetObjectiveCapturing` / `SetObjectiveCaptured`.

### 2. `Player.CheckArea()` — public quest timer follows the player

PQ membership was only dropped when moving into the "no PQ area" sentinel (`pqarea == 31`). Moving from one PQ area straight into another — or into any area with no matching PQ — left the player on the old quest's `ActivePlayers` list, still receiving its stage timer long after leaving the area.

Membership is now dropped on any area change, and re-added below when the new area maps to a PQ. `RemovePlayer` already emits `F_OBJECTIVE_UPDATE` with `0`, which clears the tracker client-side.

### 3. `.campaign objdiag` — new

`BattlefieldObjective.SendDiagnostic()` already existed but nothing ever called it; `.campaign diag` reports campaign victory points and keep status only. There was no way to inspect an objective's real state in game.

`.campaign objdiag` reports the state, owner, control/secure progress and raw timers for the objective the player is standing at. This is what identified both issues above, and it distinguishes a server-side fault from a client display one.

### Testing

On a local server against the published database:

- Before: capturing an objective left it stuck at `0:00`, never announcing capture or spawning guards.
- After: `Contested → Secure → Guarded` completes, the capture is announced and guards spawn. Verified on Martyr's Square in Praag.
- PQ tracker now clears when leaving a PQ area instead of persisting into unrelated zones.

Two notes on scope, in the interest of being straight about what was and wasn't verified:

- An earlier version of this branch also rebroadcast the objective countdown every 5 seconds, on the theory that the client was never told the running timer. Removing it and re-testing showed the countdown renders correctly without it — the client counts down locally from the state change — so it was dropped rather than shipped on a hunch.
- Note that an out-of-tier player receives no objective UI at all, because `AddInRange` is gated on `ValidInTier`. That is existing intended behaviour and is not changed here, but it makes objective issues easy to misdiagnose when testing at the wrong rank.

No configuration or data files are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
