### PR TITLE
Fix RvR campaign startup failing, leaving every battlefront locked

### DIFF
--- a/WorldServer/World/Battlefronts/Apocalypse/BattlefieldObjective.cs
+++ b/WorldServer/World/Battlefronts/Apocalypse/BattlefieldObjective.cs
@@ -1051,6 +1051,16 @@ namespace WorldServer.World.Battlefronts.Apocalypse
 
         private void RemoveGlow()
         {
+            // Region is => Zone?.Region, so it is null for objectives that were
+            // constructed by LoadObjectives but never added to a zone. Startup
+            // locking walks exactly those, and the NRE propagated out of
+            // LockBattleFrontsAllRegions into Core.Main's catch - which then
+            // skipped OpenActiveBattlefront, leaving every battlefront locked.
+            // Objectives then threw "Sequence contains no matching element" from
+            // GetActiveBattleFrontStatus and never progressed past capture.
+            if (Region == null)
+                return;
+
             var goList = Region.GetObjects<GameObject>().Where(x => x.Entry == 99858);
             foreach (var gameObject in goList)
             {


### PR DESCRIPTION
`BattlefieldObjective.RemoveGlow()` dereferences `Region`, which is `=> Zone?.Region` and is therefore null for objectives constructed by `LoadObjectives` that were never added to a zone. Startup locking walks exactly those, so the NRE propagates out of `LockBattleFrontsAllRegions`.

```
NullReferenceException
   at BattlefieldObjective.RemoveGlow()
   at BattlefieldObjective.SetObjectiveLocked()
   at UpperTierCampaignManager.LockBattleFrontsAllRegions(4)
   at Core.Main
```

## Why this is worse than it looks

The throw happens during `LockBattleFrontsAllRegions`, so **`OpenActiveBattlefront` never runs**. Every battlefront stays locked. Then at runtime, `GetActiveBattleFrontStatus` calls `.Single()` on an empty set:

```
WARN  Campaign.GetActiveBattleFrontStatus :: ALL BF Statuses are LOCKED
      : Sequence contains no matching element
ERROR EXCEPTION: <player> in Region 11 - StateMachineException:
      No exception listener is registered
```

The objective's state machine has no exception listener, so it dies there and objectives never progress past capture.

The symptom surfaces hours after the single startup line that explains it, which is what makes it hard to attribute — it presents as "battlefield objectives don't work" rather than as a startup failure.

## The fix

Guard the null. Locking then completes, `OpenActiveBattlefront` runs, and the campaign initialises.

## Verification

Before, on every boot:

```
Locking Battlefronts
(no "Opening Active battlefronts" - the exception aborted it)
```

After:

```
Locking Battlefronts
Opening Active battlefronts
UpperTierCampaignManager.OpenActiveBattlefront :: Unlocking objectives Empire/Chaos Tier 4 BF Id : 2
LowerTierCampaignManager.OpenActiveBattlefront :: Unlocking objectives Empire/Chaos Tier 1 BF Id : 1
Server listening to : 0.0.0.0:10300
```

Zero `ALL BF Statuses are LOCKED` errors since. Confirmed in game: a battlefield objective captured and held through its tick, which was not previously possible.

Also verified that campaign initialisation now completes with **no exception handling around it at all** — this NRE was the only thing being thrown there. Anyone carrying a local try/catch around the `LockBattleFrontsAllRegions` / `OpenActiveBattlefront` / `UpdateRegionCaptureStatus` block to survive startup should be able to drop it after this.

Builds clean against `master`, zero errors or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)